### PR TITLE
Fix mod breaking vanilla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ cython_debug/
 
 # VS Code
 .vscode/
+*.code-workspace

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fix consumables not spawning when playing vanilla with the mod installed.
+- Fix character select menu not loading when playing vanilla with the mod installed.
+
 ## [0.0.3]
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -97,15 +97,16 @@ func _on_ap_upgrade_received(upgrade_tier: int):
 
 # Base overrides
 func spawn_consumables(unit: Unit) -> void:
-	if _ap_client.connected_to_multiworld():
-		var consumable_count_start = _consumables.size()
-		.spawn_consumables(unit)
-		var consumable_count_after = _consumables.size()
-		var spawned_consumable = consumable_count_after > consumable_count_start
-		if spawned_consumable:
-			var spawned_consumable_id = _consumables.back().consumable_data.my_id
-			if spawned_consumable_id == "ap_pickup" or spawned_consumable_id == "ap_legendary_pickup":
-				_ap_client.consumable_spawned()
+	# No reason to check if connected to the multiworld, this is vanilla if
+	# we're not connected since the game should never drop ap_pickups otherwise.
+	var consumable_count_start = _consumables.size()
+	.spawn_consumables(unit)
+	var consumable_count_after = _consumables.size()
+	var spawned_consumable = consumable_count_after > consumable_count_start
+	if spawned_consumable:
+		var spawned_consumable_id = _consumables.back().consumable_data.my_id
+		if spawned_consumable_id == "ap_pickup" or spawned_consumable_id == "ap_legendary_pickup":
+			_ap_client.consumable_spawned()
 
 func on_consumable_picked_up(consumable: Node) -> void:
 	var is_ap_consumable = false

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/run/character_selection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/run/character_selection.gd
@@ -1,8 +1,8 @@
 extends "res://ui/menus/run/character_selection.gd"
-var _ap_client
 
 const LOG_NAME = "RampagingHippy-Archipelago/character_selection"
 
+var _ap_client
 var _unlocked_characters: Array = []
 
 func _ensure_ap_client():
@@ -13,10 +13,11 @@ func _ensure_ap_client():
 		return
 	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
 	_ap_client = mod_node.brotato_ap_client
-	for character in _ap_client.game_state.character_progress:
-		if _ap_client.game_state.character_progress[character].unlocked:
-			_add_character(character)
-	var _status = _ap_client.connect("character_received", self, "_on_character_received")
+	if _ap_client.connected_to_multiworld():
+		for character in _ap_client.game_state.character_progress:
+			if _ap_client.game_state.character_progress[character].unlocked:
+				_add_character(character)
+		var _status = _ap_client.connect("character_received", self, "_on_character_received")
 
 func _add_character(character_name: String):
 	var character_id = _ap_client.constants.CHARACTER_NAME_TO_ID[character_name]

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/title_screen/title_screen_menus.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/title_screen/title_screen_menus.gd
@@ -4,7 +4,6 @@ const LOG_NAME = "RampagingHippy-Archipelago/title_screen_menus"
 var _custom_menu_ap_connect
 
 func _ready():
-	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
 	_custom_menu_ap_connect = load("res://mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn").instance()
 	add_child(_custom_menu_ap_connect)
 	_custom_menu_ap_connect.visible = false


### PR DESCRIPTION
Fix a couple cases of the mod causing issues when playing without being connected to a Multiworld:

* Fix the character selection screen not opening due to the mod trying to get AP unlocked characters when it's not valid.
* Fix consumables not spawning because the mod was blocking the call to `.spawn_consumable`

Also removed an unused variable and updated the .gitigore with another VS Code file.