### PR TITLE
Fix character logic and legendary crates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix bug in rules generation where all locations were viewed accessible from the start.
+- Fix bug where character accessed rule checked if Demon was unlocked instead of the
+  relevant character.
+- Fix progression items being placed in legendary loot crate drop locations.
+  there.
+  - Note: Unlike the intended change in 0.0.4, the location type is back to `DEFAULT`,
+    and the apworld uses a manual `item_rule` for now that prevents `progression` and
+    `progression_skip_balancing` items from being placed at these locations.. This may
+    be changed in the future, however currently marking the locations as `EXCLUDED`
+    causes issues in world generation.
+
+
 ## [0.0.4]
 
 ### Fixed

--- a/apworld/brotato/Locations.py
+++ b/apworld/brotato/Locations.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from itertools import count
 from typing import get_args
 
-from BaseClasses import Location, LocationProgressType
+from BaseClasses import Location, LocationProgressType, Region
 
 from .Constants import (
     BASE_ID,
@@ -44,60 +44,57 @@ class BrotatoLocationBase:
         # Necessary to set field on frozen dataclass
         object.__setattr__(self, "id", id_)
 
-    def to_location(self, player: int) -> BrotatoLocation:
-        location = BrotatoLocation(player, name=self.name, address=self.id)
+    def to_location(self, player: int, parent: Region | None = None) -> BrotatoLocation:
+        location = BrotatoLocation(player, name=self.name, address=self.id, parent=parent)
         location.progress_type = self.progress_type
         return location
 
 
 _wave_count = range(1, NUM_WAVES + 1)
 
-_char_specific_wave_complete_locs: list[BrotatoLocationBase] = []
-_char_specific_run_complete_locs: list[BrotatoLocationBase] = []
-character_specific_locations: dict[str, dict[str, int | None]] = {}
+_character_wave_complete_locations: list[BrotatoLocationBase] = []
+_character_run_won_locations: list[BrotatoLocationBase] = []
 for char in CHARACTERS:
     _char_wave_complete_locations = [
         BrotatoLocationBase(name=WAVE_COMPLETE_LOCATION_TEMPLATE.format(wave=w, char=char)) for w in _wave_count
     ]
     _char_run_complete_location = BrotatoLocationBase(name=RUN_COMPLETE_LOCATION_TEMPLATE.format(char=char))
-    _char_specific_wave_complete_locs += _char_wave_complete_locations
-    _char_specific_run_complete_locs.append(_char_run_complete_location)
+    _character_wave_complete_locations += _char_wave_complete_locations
+    _character_run_won_locations.append(_char_run_complete_location)
 
-    character_specific_locations[char] = {
-        # **{c.name: c.id for c in _char_wave_complete_locations}, # We want to manually add these later
-        _char_run_complete_location.name: _char_run_complete_location.id,
-    }
 
-_shop_item_locs: list[BrotatoLocationBase] = []
+_shop_item_locations: list[BrotatoLocationBase] = []
 for tier, max_shop_locs in MAX_SHOP_LOCATIONS_PER_TIER.items():
-    _shop_item_locs += [
+    _shop_item_locations += [
         BrotatoLocationBase(name=SHOP_ITEM_LOCATION_TEMPLATE.format(tier=tier.value, num=i))
         for i in range(1, max_shop_locs + 1)
     ]
 
-_normal_item_drop_locs = [
+_loot_crate_drop_locations = [
     BrotatoLocationBase(name=CRATE_DROP_LOCATION_TEMPLATE.format(num=i)) for i in range(1, MAX_NORMAL_CRATE_DROPS + 1)
 ]
-_legendary_item_drop_locs = [
+_legendary_loot_crate_drop_locations = [
     BrotatoLocationBase(
-        name=LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE.format(num=i), progress_type=LocationProgressType.EXCLUDED
+        name=LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE.format(num=i),
     )
     for i in range(1, MAX_LEGENDARY_CRATE_DROPS + 1)
 ]
 
-location_table: list[BrotatoLocationBase] = [
-    *_char_specific_wave_complete_locs,
-    *_char_specific_run_complete_locs,
-    *_shop_item_locs,
-    *_normal_item_drop_locs,
-    *_legendary_item_drop_locs,
+_all_locations: list[BrotatoLocationBase] = [
+    *_character_wave_complete_locations,
+    *_character_run_won_locations,
+    *_shop_item_locations,
+    *_loot_crate_drop_locations,
+    *_legendary_loot_crate_drop_locations,
 ]
 
-location_name_to_id: dict[str, int] = {loc.name: loc.id for loc in location_table}
+location_table: dict[str, BrotatoLocationBase] = {loc.name: loc for loc in _all_locations}
+
+location_name_to_id: dict[str, int] = {loc.name: loc.id for loc in _all_locations}
 location_name_groups: dict[str, set[str]] = {
-    "Wave Complete Specific Character": set(c.name for c in _char_specific_wave_complete_locs),
-    "Run Win Specific Character": set(c.name for c in _char_specific_run_complete_locs),
-    "Normal Crate Drops": set(c.name for c in _normal_item_drop_locs),
-    "Legendary Crate Drops": set(c.name for c in _legendary_item_drop_locs),
-    "Shop Items": set(c.name for c in _shop_item_locs),
+    "Wave Complete Specific Character": set(c.name for c in _character_wave_complete_locations),
+    "Run Win Specific Character": set(c.name for c in _character_run_won_locations),
+    "Normal Crate Drops": set(c.name for c in _loot_crate_drop_locations),
+    "Legendary Crate Drops": set(c.name for c in _legendary_loot_crate_drop_locations),
+    "Shop Items": set(c.name for c in _shop_item_locations),
 }

--- a/apworld/brotato/Regions.py
+++ b/apworld/brotato/Regions.py
@@ -2,20 +2,16 @@ from __future__ import annotations
 
 from typing import Callable, Sequence
 
-from BaseClasses import CollectionState, MultiWorld, Region
-from worlds.generic import Rules
+from BaseClasses import CollectionState, Item, ItemClassification, MultiWorld, Region
 
 from .Constants import (
     CHARACTERS,
     CRATE_DROP_LOCATION_TEMPLATE,
     LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
+    RUN_COMPLETE_LOCATION_TEMPLATE,
     WAVE_COMPLETE_LOCATION_TEMPLATE,
 )
-from .Locations import (
-    BrotatoLocation,
-    character_specific_locations,
-    location_name_to_id,
-)
+from .Locations import location_table
 from .Options import BrotatoOptions
 from .Rules import BrotatoLogic
 
@@ -24,44 +20,50 @@ def create_regions(multiworld: MultiWorld, player: int, options: BrotatoOptions,
     menu_region = Region("Menu", player, multiworld)
     crate_drop_region = Region("Loot Crates", player, multiworld)
 
-    crate_drop_locs_name_to_id = {}
     for i in range(1, options.num_common_crate_drops + 1):
-        loc_name = CRATE_DROP_LOCATION_TEMPLATE.format(num=i)
-        crate_drop_locs_name_to_id[loc_name] = location_name_to_id[loc_name]
+        location_name = CRATE_DROP_LOCATION_TEMPLATE.format(num=i)
+        crate_drop_region.locations.append(location_table[location_name].to_location(player, parent=crate_drop_region))
+
+    def legendary_loot_crate_item_rule(item: Item) -> bool:
+        return item.classification not in (
+            ItemClassification.progression,
+            ItemClassification.progression_skip_balancing,
+        )
 
     for i in range(1, options.num_legendary_crate_drops + 1):
-        loc_name = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE.format(num=i)
-        crate_drop_locs_name_to_id[loc_name] = location_name_to_id[loc_name]
+        location_name = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE.format(num=i)
+        legendary_crate_drop_location = location_table[location_name].to_location(player, parent=crate_drop_region)
+        legendary_crate_drop_location.item_rule = legendary_loot_crate_item_rule
+        crate_drop_region.locations.append(legendary_crate_drop_location)
 
-    crate_drop_region.add_locations(crate_drop_locs_name_to_id, location_type=BrotatoLocation)
     menu_region.connect(crate_drop_region, "Drop Loot Crates")
 
     multiworld.regions += [menu_region, crate_drop_region]
 
     character_regions = []
     for character in CHARACTERS:
-        char_in_game_region = Region(f"In-Game ({character})", player, multiworld)
+        character_region = Region(f"In-Game ({character})", player, multiworld)
         has_character_rule = _create_char_region_access_rule(player, character)
-        char_in_game_locations = character_specific_locations[character]
-        char_in_game_region.add_locations(char_in_game_locations, location_type=BrotatoLocation)
+        character_run_won_location = location_table[RUN_COMPLETE_LOCATION_TEMPLATE.format(char=character)]
+        character_region.locations.append(character_run_won_location.to_location(player, parent=character_region))
 
         char_wave_drop_location_names = [
             WAVE_COMPLETE_LOCATION_TEMPLATE.format(wave=w, char=character) for w in waves_with_drops
         ]
-        char_in_game_region.add_locations(
-            {loc: location_name_to_id[loc] for loc in char_wave_drop_location_names},
-            location_type=BrotatoLocation,
+        character_region.locations.extend(
+            location_table[loc].to_location(player, parent=character_region) for loc in char_wave_drop_location_names
         )
         menu_region.connect(
-            char_in_game_region,
+            character_region,
             f"Start Game ({character})",
             rule=has_character_rule,
         )
 
-        # Crates can be gotten with any character
-        char_in_game_region.connect(crate_drop_region, f"Drop crates for {character}")
-        crate_drop_region.connect(char_in_game_region, f"Exit drop crates for {character}", rule=has_character_rule)
-        character_regions.append(char_in_game_region)
+        # Crates can be gotten with any character...
+        character_region.connect(crate_drop_region, f"Drop crates for {character}")
+        # ...but we need to make sure you don't go to another character's in-game before you have them.
+        crate_drop_region.connect(character_region, f"Exit drop crates for {character}", rule=has_character_rule)
+        character_regions.append(character_region)
 
     multiworld.regions += character_regions
 

--- a/apworld/brotato/Regions.py
+++ b/apworld/brotato/Regions.py
@@ -24,6 +24,8 @@ def create_regions(multiworld: MultiWorld, player: int, options: BrotatoOptions,
         location_name = CRATE_DROP_LOCATION_TEMPLATE.format(num=i)
         crate_drop_region.locations.append(location_table[location_name].to_location(player, parent=crate_drop_region))
 
+    # Prevent progression items from being placed at legendary loot crate drops.
+    # TODO: Ideally we would make the locations EXCLUDED, but that causes fill problems.
     def legendary_loot_crate_item_rule(item: Item) -> bool:
         return item.classification not in (
             ItemClassification.progression,

--- a/apworld/brotato/Rules.py
+++ b/apworld/brotato/Rules.py
@@ -1,17 +1,12 @@
-from typing import Protocol
+from BaseClasses import CollectionState
 
 from ..AutoWorld import LogicMixin
 from .Items import ItemName
 
 
-class HasItem(Protocol):
-    def has(self, item: str, player: int, count: int = 1) -> bool:
-        ...
-
-
 class BrotatoLogic(LogicMixin):
-    def _brotato_has_character(self: HasItem, player: int, character: str) -> bool:
+    def _brotato_has_character(self: CollectionState, player: int, character: str) -> bool:
         return self.has(character, player)
 
-    def _brotato_has_run_wins(self: HasItem, player: int, count: int) -> bool:
+    def _brotato_has_run_wins(self: CollectionState, player: int, count: int) -> bool:
         return self.has(ItemName.RUN_COMPLETE.value, player, count=count)


### PR DESCRIPTION
Fix bugs causing most locations to be placed in sphere 0:

None of the entrances from the `"Loot Crates"` region to the `"In-Game ({character})"` regions had access rules, which meant that if you had one character unlocked (i.e. always), then all locations in the game were in logic. This was fixed by adding the same "has character" check used for the entrances in the reverse direction to the aforementioned entrances.

Related, there was a bug in the rule where, due to Python's late-binding, the local function would always check if Demon was unlocked, since that's the last character in the list. Fixed by moving the local function to be an internal function in `./apworld/brotato/Regions.py`

Next, legendary loot crate drops were still allowing progression items to be placed there, due to locations not being created and added to regions properly. This was fixed, and we manually create locations and add to the regions as a result now (this also seems to be the way a lot of other worlds handle it). 

In addition, legendary loot crates locations have been changed from `EXCLUDED` to `DEFAULT`, with a custom `item_rule` to make it so `progression` and `progression_skip_balancing` items can't be placed at them. This fixes an issue when filling where we don't have enough filler items. This is probably just a math error on my part, but this is easier and close enough in the short term.

Finally, renamed a lot of the location/region-related variables in the `apworld` to be more descriptive and consistent. Also took the opportunity to clean up variables that aren't used anymore, and change the structure of others to be more useful.