### PR TITLE
Fix various issues missed when updating connection handling.

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -2,12 +2,12 @@ extends "res://main.gd"
 
 const LOG_NAME = "RampagingHippy-Archipelago/main"
 
-var _ap_gift_common = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_common.tres")
-var _ap_gift_uncommon = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_uncommon.tres")
-var _ap_gift_rare = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_rare.tres")
-var _ap_gift_legendary = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_legendary.tres")
+var _ap_gift_common = preload ("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_common.tres")
+var _ap_gift_uncommon = preload ("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_uncommon.tres")
+var _ap_gift_rare = preload ("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_rare.tres")
+var _ap_gift_legendary = preload ("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_legendary.tres")
 
-export (Resource) var ap_upgrade_to_process_icon = preload("res://mods-unpacked/RampagingHippy-Archipelago/ap_upgrade_icon.png")
+export(Resource) var ap_upgrade_to_process_icon = preload ("res://mods-unpacked/RampagingHippy-Archipelago/ap_upgrade_icon.png")
 
 # Extensions
 var _drop_ap_pickup = true;
@@ -18,11 +18,11 @@ func _ready() -> void:
 	_ap_client = mod_node.brotato_ap_client
 	
 	if _ap_client.connected_to_multiworld():
-		if RunData.current_wave == 1:
+		if RunData.current_wave == DebugService.starting_wave:
 			# Run started, initialize/reset some values
 			_ap_client.run_started()
 			var ap_game_data = _ap_client.game_state
-			ModLoaderLog.debug("Start of AP run, giving player %d XP and %d gold." % 
+			ModLoaderLog.debug("Start of AP run, giving player %d XP and %d gold." %
 				[
 					ap_game_data.starting_xp,
 					ap_game_data.starting_gold
@@ -126,7 +126,6 @@ func on_consumable_picked_up(consumable: Node) -> void:
 			RunData.add_gold(RunData.effects["item_box_gold"])
 			RunData.tracked_item_effects["item_bag"] += RunData.effects["item_box_gold"]
 	.on_consumable_picked_up(consumable)
-
 
 func _on_WaveTimer_timeout() -> void:
 	if _ap_client.connected_to_multiworld():

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -9,7 +9,7 @@ export onready var ap_websocket_connection
 export onready var brotato_ap_client
 export onready var ap_player_session
 
-func _init(_modLoader = ModLoader):
+func _init(_modLoader=ModLoader):
 	ModLoaderLog.info("Init", LOG_NAME)
 
 	var dir = ModLoaderMod.get_unpacked_dir() + MOD_NAME + "/"
@@ -29,9 +29,8 @@ func _init(_modLoader = ModLoader):
 
 	# Add translations
 	ModLoaderMod.add_translation(dir + "translations/modname.en.translation")
-	
 
-func _ready()->void:
+func _ready() -> void:
 	# TODO: Proper translations
 	ModLoaderLog.info(str("Translation Demo: ", tr("MODNAME_READY_TEXT")), LOG_NAME)
 	ModLoaderLog.success("Loaded", LOG_NAME)
@@ -49,7 +48,7 @@ func _ready()->void:
 	ModLoaderLog.debug("Added AP session", LOG_NAME)
 
 	var _brotato_ap_client_namespace = load("res://mods-unpacked/RampagingHippy-Archipelago/singletons/brotato_ap_client.gd")
-	brotato_ap_client = _brotato_ap_client_namespace.new(ap_websocket_connection)
+	brotato_ap_client = _brotato_ap_client_namespace.new(ap_player_session)
 	self.add_child(brotato_ap_client)
 	ModLoaderLog.debug("Added AP client", LOG_NAME)
 


### PR DESCRIPTION
This is what I get for not fully testing after #8 .

Most of the changes are to update `brotato_ap_client` to use a `ap_player_session` instance instead of the a `ap_websocket_connection_instance`, and make `mod_main` give the session to the `brotato_ap_client` constructor instead of the WS connection.

There's also a bonus change to fix mod run state not initializing if we used the `DebugService` to set the starting wave to something other than 1.

No changelog updates because none of these were released.