### PR TITLE
Give player gold and XP items once, not every run.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added AP logo image to the connection menu to show the state of the connection.
 - Connection menu now shows an error message when a connection error occurs.
+- (Internal) Mod now properly detects if the player quits a game early or restarts it.
+  - This is a needed change to ensure they are given gold and XP items at the right time
+    (see `Changed` section below).
+- (Internal) Total gold and XP given to the player is now tracked using two data storage entries
+  per Brotato player in the multiworld.
+  - Another needed change to support giving players gold and XP items only once. Using
+    data storage lets us track the value outside the game.
 
 ### Fixed
 - Connection to server should properly handle connection errors now.
 - Connection to server now times out if it can't reach the server.
 
 ### Changed
+- Gold and XP items are now given to players once in their current run or the next run
+  after they receive the item, not in every run.
+  - This should keep players from getting too strong too fast and trivializing their
+    playthrough.
 - Connecting to multiworld no longer needs to reconnect to the server if already connected.
   - This makes the process more closely follow the [Archipelago Connection
     Handshake](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#archipelago-connection-handshake).

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/menu_confirm.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/menu_confirm.gd
@@ -1,0 +1,14 @@
+extends "res://ui/menus/pages/menu_confirm.gd"
+
+const LOG_NAME = "RampagingHippy-Archipelago/menu_confirm"
+
+var _ap_client
+
+func _ready():
+	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
+	_ap_client = mod_node.brotato_ap_client
+
+func _on_ConfirmButton_pressed() -> void:
+	ModLoaderLog.debug("Quitting current run", LOG_NAME)
+	_ap_client.run_finished()
+	._on_ConfirmButton_pressed()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/menu_restart.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/menu_restart.gd
@@ -1,0 +1,17 @@
+extends "res://ui/menus/pages/menu_restart.gd"
+
+const LOG_NAME = "RampagingHippy-Archipelago/menu_restart"
+
+var _ap_client
+
+func _ready():
+	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
+	_ap_client = mod_node.brotato_ap_client
+
+func _on_ConfirmButton_pressed() -> void:
+	# The base class does this, so probably better that we do too
+	if confirm_button_pressed:
+		return
+	ModLoaderLog.debug("Restarting current run", LOG_NAME)
+	_ap_client.run_finished()
+	._on_ConfirmButton_pressed()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -19,7 +19,11 @@ func _init(_modLoader=ModLoader):
 	var extension_files = [
 		"main.gd", # Update consumable drop logic to spawn AP items
 		"singletons/item_service.gd", # Drop AP consumables
-		"ui/menus/pages/main_menu.gd", # Add AP connect button to main menu
+		"ui/menus/pages/main_menu.gd", # Add AP connect
+		# Detect when game is quit when the "Return to main menu" confirmation button is pressed
+		"ui/menus/pages/menu_confirm.gd",
+		# Detect when game is restart when the "Restart" confirmation button is pressed
+		"ui/menus/pages/menu_restart.gd",
 		"ui/menus/title_screen/title_screen_menus.gd", # Swtich to connect menu when connect button is pressed
 		"ui/menus/run/character_selection.gd", # Only unlock characters received in MultiWorld
 	]

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/singletons/ap_types.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/singletons/ap_types.gd
@@ -30,6 +30,49 @@ enum ClientStatus {
 	CLIENT_GOAL = 30
 }
 
+enum DataStorageOperationType {
+	REPLACE = 0
+	DEFAULT = 1
+	ADD = 2
+	MUL = 3
+	POW = 4
+	MOD = 5
+	FLOOR = 6
+	CEIL = 7
+	MAX = 8
+	MIN = 9
+	AND = 10
+	OR = 11
+	XOR = 12
+	LEFT_SHIFT = 13
+	RIGHT_SHIFT = 14
+	REMOVE = 15
+	POP = 16
+	UPDATE = 17
+
+}
+
+const data_storage_operation_to_name = {
+	DataStorageOperationType.REPLACE: "replace",
+	DataStorageOperationType.DEFAULT: "default",
+	DataStorageOperationType.ADD: "add",
+	DataStorageOperationType.MUL: "mul",
+	DataStorageOperationType.POW: "pow",
+	DataStorageOperationType.MOD: "mod",
+	DataStorageOperationType.FLOOR: "floor",
+	DataStorageOperationType.CEIL: "ceil",
+	DataStorageOperationType.MAX: "max",
+	DataStorageOperationType.MIN: "min",
+	DataStorageOperationType.AND: "and",
+	DataStorageOperationType.OR: "or",
+	DataStorageOperationType.XOR: "xor",
+	DataStorageOperationType.LEFT_SHIFT: "left_shift",
+	DataStorageOperationType.RIGHT_SHIFT: "right_shift",
+	DataStorageOperationType.REMOVE: "remove",
+	DataStorageOperationType.POP: "pop",
+	DataStorageOperationType.UPDATE: "update",
+}
+
 class NetworkVersion:
 	var major: int
 	var minor: int
@@ -42,7 +85,6 @@ class NetworkVersion:
 		network_version.build = data["build"]
 
 		return network_version
-
 
 class NetworkPlayer:
 	var team: int
@@ -182,7 +224,7 @@ class Bounced:
 	var data: Dictionary
 
 class InvalidPacket:
-	var type : String
+	var type: String
 	var original_cmd: String
 	var text: String
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/singletons/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/singletons/ap_websocket_connection.gd
@@ -228,7 +228,10 @@ func _on_data_received():
 func _send_command(args: Dictionary):
 	ModLoaderLog.info("Sending %s command" % args["cmd"], LOG_NAME)
 	var command_str = JSON.print([args])
-	var _result = _peer.put_packet(command_str.to_ascii())
+	if _peer != null:
+		var _result = _peer.put_packet(command_str.to_ascii())
+	else:
+		ModLoaderLog.warning("Peer is null!", LOG_NAME)
 
 func _init_client():
 	if self._client != null:


### PR DESCRIPTION
Giving these items to the player every run resulted in them getting too strong too fast, which wasn't fun given feedback on Discord. So, instead gold and XP received is only given to players in their current run or in the next run after they receive the items.

`brotato_ap_client` and `game_state` are both updated with new methods and properties to track the relevant data and give the gold at the appropriate time. The `main` overload was also changed to not just give all gold at the start of a run.

There was quite a bit under the hood that also needed to be added and updated.

## In-run detection
We need to know if the player is in a run so we can determine whether to give them the gold and XP immediately or wait until they start a run. There's a new flag `ApGameState.run_active` which tracks this, which is set `true` via the Brotato Client whenever a run is started, and set `false` when the player wins, loses, quits or restarts a run.

We already handled the first two cases correctly, but the last two required us to add two new extension controls to the "Quit run" and "Restart run" dialogs to check when the player did those actions.

## Data storage support

To keep track of the gold and XP given between instances of the game being quit and started, we now add two data storage keys `{PLAYER}_received_gold` and `{PLAYER}_received_xp` for each Brotato player and track/update them via the [`Get`](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#get), [`Set`](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#set), and [`SetNotify`](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#setnotify)  commands.

This meant adding support for these commands to the WebSocket connection and AP player session classes, which was either absent or half-baked before this.
