### PR TITLE
Implement crate drop groups and multiple crate drops per location (apworld-side)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Loot crate drops are now organized into "groups", which are not dropped by the game
+  until a certain number of wins are obtained.
+- The number of normal and legendary loot crate groups can be configured by two new
+  options added for them.
+- Loot crates are evenly distributed among the groups, with a bias towards earlier
+  groups if there's excess.
+- Each group requires a certain number of wins before the game will drop them, which is
+  calculated by dividing the number of groups by the number of required victories for
+  goal completion. The first group is always unlocked at the start of the game.
+  - For example, if the world requires 20 wins and has 10 common crate drop groups, the
+    first group will be unlocked from the start, the second after two wins, the third
+    after four wins, etc.
+  - If the options specify more groups than the required number of wins, the number of
+    groups is clamped to the number of wins.
+
+
+
 ## [0.0.6] - 2024-03-27
 
 ### Added

--- a/apworld/brotato/Constants.py
+++ b/apworld/brotato/Constants.py
@@ -72,6 +72,11 @@ NUM_UNLOCKABLE_CHARACTERS = NUM_CHARACTERS - NUM_DEFAULT_CHARACTERS
 
 MAX_NORMAL_CRATE_DROPS = 50
 MAX_LEGENDARY_CRATE_DROPS = 50
+# Since groups are unlocked by winning runs, the maximum number of groups there is the number of characters.
+# So these are just aliases of NUM_CHARACTERS to make them more explicit.
+MAX_NORMAL_CRATE_DROP_GROUPS = NUM_CHARACTERS
+MAX_LEGENDARY_CRATE_DROP_GROUPS = NUM_CHARACTERS
+
 
 MAX_COMMON_UPGRADES = 50
 MAX_UNCOMMON_UPGRADES = 50

--- a/apworld/brotato/Constants.py
+++ b/apworld/brotato/Constants.py
@@ -88,7 +88,9 @@ MAX_SHOP_LOCATIONS_PER_TIER = {
 
 # Location name string templates
 CRATE_DROP_LOCATION_TEMPLATE = "Loot Crate {num}"
+CRATE_DROP_GROUP_LOCATION_TEMPLATE = "Loot Crate Group {num}"
 LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE = "Legendary Loot Crate {num}"
+LEGENDARY_CRATE_DROP_GROUP_LOCATION_TEMPLATE = "Legendary Loot Crate Group {num}"
 WAVE_COMPLETE_LOCATION_TEMPLATE = "Wave {wave} Completed ({char})"
 RUN_COMPLETE_LOCATION_TEMPLATE = "Run Won ({char})"
 SHOP_ITEM_LOCATION_TEMPLATE = "{tier} Shop Item {num}"

--- a/apworld/brotato/Constants.py
+++ b/apworld/brotato/Constants.py
@@ -88,9 +88,11 @@ MAX_SHOP_LOCATIONS_PER_TIER = {
 
 # Location name string templates
 CRATE_DROP_LOCATION_TEMPLATE = "Loot Crate {num}"
-CRATE_DROP_GROUP_LOCATION_TEMPLATE = "Loot Crate Group {num}"
 LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE = "Legendary Loot Crate {num}"
-LEGENDARY_CRATE_DROP_GROUP_LOCATION_TEMPLATE = "Legendary Loot Crate Group {num}"
 WAVE_COMPLETE_LOCATION_TEMPLATE = "Wave {wave} Completed ({char})"
 RUN_COMPLETE_LOCATION_TEMPLATE = "Run Won ({char})"
 SHOP_ITEM_LOCATION_TEMPLATE = "{tier} Shop Item {num}"
+
+# Region name string templates
+CRATE_DROP_GROUP_REGION_TEMPLATE = "Loot Crate Group {num}"
+LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE = "Legendary Loot Crate Group {num}"

--- a/apworld/brotato/Options.py
+++ b/apworld/brotato/Options.py
@@ -108,8 +108,9 @@ class NumberCommonCrateDropGroups(Range):
 
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
-    default = 1
+
     display_name = "Loot Crate Groups"
+    default = 1
 
 
 class NumberLegendaryCrateDropLocations(Range):
@@ -225,7 +226,7 @@ class BrotatoOptions(PerGameCommonOptions):
     num_common_crate_drop_groups: NumberCommonCrateDropGroups
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
     num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
-    num_common_crate_drop_groups: NumberLegendaryCrateDropGroups
+    num_legendary_crate_drop_groups: NumberLegendaryCrateDropGroups
     num_common_upgrades: NumberCommonUpgrades
     num_uncommon_upgrades: NumberUncommonUpgrades
     num_rare_upgrades: NumberRareUpgrades

--- a/apworld/brotato/Options.py
+++ b/apworld/brotato/Options.py
@@ -6,8 +6,10 @@ from Options import PerGameCommonOptions, Range, TextChoice
 
 from .Constants import (
     MAX_COMMON_UPGRADES,
+    MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
     MAX_LEGENDARY_UPGRADES,
+    MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
     MAX_RARE_UPGRADES,
     MAX_SHOP_LOCATIONS_PER_TIER,
@@ -107,7 +109,7 @@ class NumberCommonCrateDropGroups(Range):
     """
 
     range_start = 1
-    range_end = MAX_NORMAL_CRATE_DROPS
+    range_end = MAX_NORMAL_CRATE_DROP_GROUPS
 
     display_name = "Loot Crate Groups"
     default = 1
@@ -152,7 +154,7 @@ class NumberLegendaryCrateDropGroups(Range):
     """
 
     range_start = 1
-    range_end = MAX_NORMAL_CRATE_DROPS
+    range_end = MAX_LEGENDARY_CRATE_DROP_GROUPS
     default = 1
     display_name = "Loot Crate Groups"
 

--- a/apworld/brotato/Options.py
+++ b/apworld/brotato/Options.py
@@ -68,27 +68,48 @@ class WavesPerCheck(Range):
 
 
 class NumberCommonCrateDropLocations(Range):
-    """
-    The first <count> normal crate drops will be AP locations.
+    """The number of locations which will be locked behind picking up loot crates."""
+
+    range_start = 0
+    range_end = MAX_NORMAL_CRATE_DROPS
+
+    display_name = "Number of loot crate drop locations"
+    default = 25
+
+
+class NumberCommonCrateDropsPerCheck(Range):
+    """The number of loot crates needed to check a location.
+
+    1 means every loot crate pickup gives a check, 2 means every other loot crate, etc.
     """
 
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
 
-    display_name = "Number of normal crate drop locations"
-    default = 25
+    display_name = "Loot crates per check"
 
 
 class NumberLegendaryCrateDropLocations(Range):
-    """
-    The first <count> legendary crate drops will be AP locations.
-    """
+    """The number of locations which will be locked behind picking up legendary loot
+    crates."""
 
     range_start = 0
     range_end = MAX_LEGENDARY_CRATE_DROPS
 
     display_name = "Number of legendary crate drop locations"
     default = 5
+
+
+class NumberLegendaryCrateDropsPerCheck(Range):
+    """The number of legendary loot crates needed to check a location.
+
+    1 means every loot crate pickup gives a check, 2 means every other loot crate, etc.
+    """
+
+    range_start = 0
+    range_end = MAX_NORMAL_CRATE_DROPS
+
+    display_name = "Loot crates per check"
 
 
 class NumberCommonUpgrades(Range):
@@ -156,7 +177,9 @@ class BrotatoOptions(PerGameCommonOptions):
     num_starting_characters: NumberStartingCharacters
     waves_per_drop: WavesPerCheck
     num_common_crate_drops: NumberCommonCrateDropLocations
+    num_common_crate_drops_per_check: NumberCommonCrateDropsPerCheck
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
+    num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
     num_common_upgrades: NumberCommonUpgrades
     num_uncommon_upgrades: NumberUncommonUpgrades
     num_rare_upgrades: NumberRareUpgrades

--- a/apworld/brotato/Options.py
+++ b/apworld/brotato/Options.py
@@ -68,30 +68,57 @@ class WavesPerCheck(Range):
 
 
 class NumberCommonCrateDropLocations(Range):
-    """The number of locations which will be locked behind picking up loot crates."""
+    """The number of loot crate locations.
+
+    This replaces the loot crate drops in-game with an Archipelago item which must be picked up.
+
+    How the drops are made available and how many are needed to make a check are controlled by the next two settings.
+    """
 
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
 
-    display_name = "Number of loot crate drop locations"
+    display_name = "Number of normal crate drop locations"
     default = 25
 
 
 class NumberCommonCrateDropsPerCheck(Range):
     """The number of loot crates needed to check a location.
 
-    1 means every loot crate pickup gives a check, 2 means every other loot crate, etc.
+    1 means every loot crate pickup gives a check,
+    2 means every other loot crate,
+    etc.
     """
 
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
 
-    display_name = "Loot crates per check"
+    display_name = "Loot Crates per Check"
+
+
+class NumberCommonCrateDropGroups(Range):
+    """The number of groups to separate loot crate locations into.
+
+    Once you check all the locations in a group, the randomizer will not drop more loot crate Archipelago items until you win more runs.
+
+    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out over the number of wins you choose.
+
+    Set to 1 to make all loot crate locations available from the start.
+    """
+
+    range_start = 0
+    range_end = MAX_NORMAL_CRATE_DROPS
+    default = 1
+    display_name = "Loot Crate Groups"
 
 
 class NumberLegendaryCrateDropLocations(Range):
-    """The number of locations which will be locked behind picking up legendary loot
-    crates."""
+    """The number of legendary loot crate locations.
+
+    This replaces the legendary loot crate drops in-game with an Archipelago item which must be picked up.
+
+    How the drops are made available and how many are needed to make a check are controlled by the next two settings.
+    """
 
     range_start = 0
     range_end = MAX_LEGENDARY_CRATE_DROPS
@@ -108,8 +135,25 @@ class NumberLegendaryCrateDropsPerCheck(Range):
 
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
+    default = 1
 
     display_name = "Loot crates per check"
+
+
+class NumberLegendaryCrateDropGroups(Range):
+    """The number of groups to separate legendary loot crate locations into.
+
+    Once you check all the locations in a group, the randomizer will not drop more legendary loot crate Archipelago items until you win more runs.
+
+    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out over the number of wins you choose.
+
+    Set to 1 to make all legendary loot crate locations available from the start.
+    """
+
+    range_start = 0
+    range_end = MAX_NORMAL_CRATE_DROPS
+    default = 1
+    display_name = "Loot Crate Groups"
 
 
 class NumberCommonUpgrades(Range):
@@ -178,8 +222,10 @@ class BrotatoOptions(PerGameCommonOptions):
     waves_per_drop: WavesPerCheck
     num_common_crate_drops: NumberCommonCrateDropLocations
     num_common_crate_drops_per_check: NumberCommonCrateDropsPerCheck
+    num_common_crate_drop_groups: NumberCommonCrateDropGroups
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
     num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
+    num_common_crate_drop_groups: NumberLegendaryCrateDropGroups
     num_common_upgrades: NumberCommonUpgrades
     num_uncommon_upgrades: NumberUncommonUpgrades
     num_rare_upgrades: NumberRareUpgrades

--- a/apworld/brotato/Options.py
+++ b/apworld/brotato/Options.py
@@ -106,7 +106,7 @@ class NumberCommonCrateDropGroups(Range):
     Set to 1 to make all loot crate locations available from the start.
     """
 
-    range_start = 0
+    range_start = 1
     range_end = MAX_NORMAL_CRATE_DROPS
 
     display_name = "Loot Crate Groups"
@@ -151,7 +151,7 @@ class NumberLegendaryCrateDropGroups(Range):
     Set to 1 to make all legendary loot crate locations available from the start.
     """
 
-    range_start = 0
+    range_start = 1
     range_end = MAX_NORMAL_CRATE_DROPS
     default = 1
     display_name = "Loot Crate Groups"

--- a/apworld/brotato/Rules.py
+++ b/apworld/brotato/Rules.py
@@ -1,12 +1,31 @@
-from BaseClasses import CollectionState
+from BaseClasses import CollectionState, Item, ItemClassification
+from worlds.generic.Rules import CollectionRule
 
-from ..AutoWorld import LogicMixin
 from .Items import ItemName
 
 
-class BrotatoLogic(LogicMixin):
-    def _brotato_has_character(self: CollectionState, player: int, character: str) -> bool:
-        return self.has(character, player)
+def create_has_run_wins_rule(player: int, count: int) -> CollectionRule:
+    def has_wins(state: CollectionState) -> bool:
+        return state.has(ItemName.RUN_COMPLETE.value, player, count)
 
-    def _brotato_has_run_wins(self: CollectionState, player: int, count: int) -> bool:
-        return self.has(ItemName.RUN_COMPLETE.value, player, count=count)
+    return has_wins
+
+
+def create_has_character_rule(player: int, character: str) -> CollectionRule:
+    def char_region_access_rule(state: CollectionState):
+        return state.has(character, player)
+
+    return char_region_access_rule
+
+
+def legendary_loot_crate_item_rule(item: Item) -> bool:
+    """Prevent progression items from being placed at legendary loot crate drops.
+
+    This can cause some very slow/painful BKs if not set
+
+    TODO: Ideally we would make the locations EXCLUDED, but that causes fill problems.
+    """
+    return item.classification not in (
+        ItemClassification.progression,
+        ItemClassification.progression_skip_balancing,
+    )

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -225,16 +225,19 @@ class BrotatoWorld(World):
 
         regions: List[Region] = []
         num_wins_to_unlock_group = self.options.num_victories.value // num_groups
-        items_per_group, extra_for_first_group = divmod(num_items, num_groups)
+        items_per_group, extra_items = divmod(num_items, num_groups)
         crate_count = 0
         wins_to_unlock = 0
         for group_idx in range(1, num_groups + 1):
             crate_group_region = Region(region_name_template.format(num=group_idx), self.player, self.multiworld)
             items_in_group = min(items_per_group, num_items - crate_count)
-            if group_idx == 1 and extra_for_first_group > 0:
-                # If the number of crates doesn't evenly divide into the number of groups, add the remainder to the
-                # first group. This way there's more checks in earlier spheres which should be better?
-                items_in_group += extra_for_first_group
+            if extra_items > 0:
+                # If the number of crates doesn't evenly divide into the number of groups, add 1 to each group until all
+                # the extras are used. This ensures the groups are as even as possible. The extra is the remainder of
+                # evenly dividing the number of items over the number of groups, so in the worst case every group but
+                # the last will have an extra added to it.
+                items_in_group += 1
+                extra_items -= 1
             for _ in range(1, items_in_group + 1):
                 crate_location_name = location_name_template.format(num=crate_count + 1)
                 crate_location: BrotatoLocation = location_table[crate_location_name].to_location(

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import Any, List, Literal, Sequence
 
 from BaseClasses import MultiWorld, Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
-from worlds.generic.Rules import ItemRule, add_item_rule
+from worlds.generic.Rules import add_item_rule
 
 from ._loot_crate_groups import BrotatoLootCrateGroup, build_loot_crate_groups
 from .Constants import (
@@ -211,12 +212,10 @@ class BrotatoWorld(World):
             "num_consumables": self.options.num_common_crate_drops.value,
             "num_starting_shop_slots": self.options.num_starting_shop_slots.value,
             "num_legendary_consumables": self.options.num_legendary_crate_drops.value,
-            "num_common_crate_drops_per_check": self.options.num_common_crate_drops_per_check,
-            "num_legendary_crate_drops_per_check": self.options.num_legendary_crate_drops_per_check,
-            "common_crate_drop_groups": 0,
-            "legendary_crate_drop_groups": 0,
-            "wins_per_common_crate_drop_group": 0,
-            "wins_per_legendary_crate_drop_group": 0,
+            "num_common_crate_drops_per_check": self.options.num_common_crate_drops_per_check.value,
+            "num_legendary_crate_drops_per_check": self.options.num_legendary_crate_drops_per_check.value,
+            "common_crate_drop_groups": [asdict(g) for g in self.common_loot_crate_groups],
+            "legendary_crate_drop_groups": [asdict(g) for g in self.legendary_loot_crate_groups],
         }
 
     def _create_character_region(self, parent_region: Region, character: str) -> Region:

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -57,7 +57,7 @@ class BrotatoWorld(World):
     """
 
     options_dataclass = BrotatoOptions
-    options: BrotatoOptions
+    options: BrotatoOptions  # type: ignore
     game = "Brotato"
     web = BrotatoWeb()
     data_version = 0
@@ -91,7 +91,7 @@ class BrotatoWorld(World):
         if character_option == 0:  # Default
             self._starting_characters = list(DEFAULT_CHARACTERS)
         else:
-            num_starting_characters = self.options.num_starting_characters
+            num_starting_characters = self.options.num_starting_characters.value
             self._starting_characters = self.random.sample(CHARACTERS, num_starting_characters)
 
     def set_rules(self):

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -9,10 +9,10 @@ from worlds.generic.Rules import ItemRule, add_item_rule
 
 from .Constants import (
     CHARACTERS,
-    CRATE_DROP_GROUP_LOCATION_TEMPLATE,
+    CRATE_DROP_GROUP_REGION_TEMPLATE,
     CRATE_DROP_LOCATION_TEMPLATE,
     DEFAULT_CHARACTERS,
-    LEGENDARY_CRATE_DROP_GROUP_LOCATION_TEMPLATE,
+    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
     LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
     MAX_SHOP_SLOTS,
     NUM_WAVES,
@@ -214,13 +214,13 @@ class BrotatoWorld(World):
             num_items = self.options.num_common_crate_drops.value
             num_groups = self.options.num_common_crate_drop_groups.value
             location_name_template = CRATE_DROP_LOCATION_TEMPLATE
-            region_name_template = CRATE_DROP_GROUP_LOCATION_TEMPLATE
+            region_name_template = CRATE_DROP_GROUP_REGION_TEMPLATE
             item_rule = None
         else:
             num_items = self.options.num_legendary_crate_drops.value
             num_groups = self.options.num_legendary_crate_drop_groups.value
             location_name_template = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE
-            region_name_template = LEGENDARY_CRATE_DROP_GROUP_LOCATION_TEMPLATE
+            region_name_template = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE
             item_rule = legendary_loot_crate_item_rule
 
         regions: List[Region] = []

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -212,19 +212,25 @@ class BrotatoWorld(World):
         item_rule: ItemRule | None
         if crate_type == "normal":
             num_items = self.options.num_common_crate_drops.value
-            num_groups = self.options.num_common_crate_drop_groups.value
+            num_groups_option_value = self.options.num_common_crate_drop_groups.value
             location_name_template = CRATE_DROP_LOCATION_TEMPLATE
             region_name_template = CRATE_DROP_GROUP_REGION_TEMPLATE
             item_rule = None
         else:
             num_items = self.options.num_legendary_crate_drops.value
-            num_groups = self.options.num_legendary_crate_drop_groups.value
+            num_groups_option_value = self.options.num_legendary_crate_drop_groups.value
             location_name_template = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE
             region_name_template = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE
             item_rule = legendary_loot_crate_item_rule
 
         regions: List[Region] = []
-        num_wins_to_unlock_group = self.options.num_victories.value // num_groups
+
+        # If the options specify more crate drop groups than number of required wins, clamp to the number of wins. This
+        # makes the math simpler and ensures all items are accessible by go mode. Someone probably wants the option to
+        # have items after completing their goal, but we're going to pretend they don't exist until they ask.
+        num_groups = min(self.options.num_victories.value, num_groups_option_value)
+
+        num_wins_to_unlock_group = max(self.options.num_victories.value // num_groups, 1)
         items_per_group, extra_items = divmod(num_items, num_groups)
         crate_count = 0
         wins_to_unlock = 0

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -29,7 +29,7 @@ from .Items import (
 )
 from .Locations import BrotatoLocation, location_name_groups, location_name_to_id, location_table
 from .Options import BrotatoOptions
-from .Rules import BrotatoLogic, create_has_character_rule, create_has_run_wins_rule, legendary_loot_crate_item_rule
+from .Rules import create_has_character_rule, create_has_run_wins_rule, legendary_loot_crate_item_rule
 
 logger = logging.getLogger("Brotato")
 
@@ -96,8 +96,8 @@ class BrotatoWorld(World):
 
     def set_rules(self):
         num_required_victories = self.options.num_victories.value
-        self.multiworld.completion_condition[self.player] = lambda state: BrotatoLogic._brotato_has_run_wins(
-            state, self.player, count=num_required_victories
+        self.multiworld.completion_condition[self.player] = create_has_run_wins_rule(
+            self.player, num_required_victories
         )
 
     def create_regions(self) -> None:
@@ -225,12 +225,16 @@ class BrotatoWorld(World):
 
         regions: List[Region] = []
         num_wins_to_unlock_group = self.options.num_victories.value // num_groups
-        items_per_group = num_items // num_groups
+        items_per_group, extra_for_first_group = divmod(num_items, num_groups)
         crate_count = 0
         wins_to_unlock = 0
         for group_idx in range(1, num_groups + 1):
             crate_group_region = Region(region_name_template.format(num=group_idx), self.player, self.multiworld)
             items_in_group = min(items_per_group, num_items - crate_count)
+            if group_idx == 1 and extra_for_first_group > 0:
+                # If the number of crates doesn't evenly divide into the number of groups, add the remainder to the
+                # first group. This way there's more checks in earlier spheres which should be better?
+                items_in_group += extra_for_first_group
             for _ in range(1, items_in_group + 1):
                 crate_location_name = location_name_template.format(num=crate_count + 1)
                 crate_location: BrotatoLocation = location_table[crate_location_name].to_location(

--- a/apworld/brotato/_loot_crate_groups.py
+++ b/apworld/brotato/_loot_crate_groups.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass(frozen=True)
+class BrotatoLootCrateGroup:
+    index: int
+    num_crates: int
+    wins_to_unlock: int
+
+
+def build_loot_crate_groups(num_crates: int, num_groups: int, num_victories: int) -> Tuple[BrotatoLootCrateGroup, ...]:
+    # If the options specify more crate drop groups than number of required wins, clamp to the number of wins. This
+    # makes the math simpler and ensures all items are accessible by go mode. Someone probably wants the option to have
+    # items after completing their goal, but we're going to pretend they don't exist until they ask.
+    num_groups_actual = min(num_groups, num_victories)
+
+    crates_allocated = 0
+    wins_to_unlock_group = 0
+    num_wins_to_unlock_group = max(num_victories // num_groups_actual, 1)
+    crates_per_group, extra_crates = divmod(num_crates, num_groups_actual)
+    loot_crate_groups: List[BrotatoLootCrateGroup] = []
+
+    for group_count in range(1, num_groups_actual + 1):
+        crates_in_group = min(crates_per_group, num_crates - crates_allocated)
+
+        if extra_crates > 0:
+            # If the number of crates doesn't evenly divide into the number of groups, add 1 to each group until all the
+            # extras are used. This ensures the groups are as even as possible. The extra is the remainder of evenly
+            # dividing the number of items over the number of groups, so in the worst case every group but the last will
+            # have an extra added to it.
+            crates_in_group += 1
+            extra_crates -= 1
+
+        crates_allocated += crates_in_group
+
+        loot_crate_groups.append(
+            BrotatoLootCrateGroup(index=group_count, num_crates=crates_in_group, wins_to_unlock=wins_to_unlock_group)
+        )
+        # Set this for the next group now. This is the easiest way to ensure group 1 requires 0 victories.
+        wins_to_unlock_group = min(wins_to_unlock_group + num_wins_to_unlock_group, num_victories)
+
+    return tuple(loot_crate_groups)

--- a/apworld/brotato/test/__init__.py
+++ b/apworld/brotato/test/__init__.py
@@ -1,10 +1,10 @@
-from typing import ClassVar
-from .. import BrotatoWorld
-
 from test.bases import WorldTestBase
+from typing import ClassVar
+
+from .. import BrotatoWorld
 
 
 class BrotatoTestBase(WorldTestBase):
     game = "Brotato"
-    world: BrotatoWorld
+    world: BrotatoWorld  # type: ignore
     player: ClassVar[int] = 1

--- a/apworld/brotato/test/__init__.py
+++ b/apworld/brotato/test/__init__.py
@@ -3,7 +3,7 @@ from test.bases import WorldTestBase
 from typing import ClassVar
 
 from .. import BrotatoWorld
-from ._data_sets import TEST_DATA_SETS, BrotatoTestDataSet
+from ._data_sets import TEST_DATA_SETS
 
 
 class BrotatoTestBase(WorldTestBase):
@@ -14,13 +14,13 @@ class BrotatoTestBase(WorldTestBase):
     def _test_data_set_subtests(self):
         for test_data in TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
-                self._run(test_data)
+                self._run(asdict(test_data.options))
                 yield test_data
 
-    def _run(self, test_data: BrotatoTestDataSet):
+    def _run(self, options: dict):
         """Setup the world using the options from the dataset.
 
         We make this distinct from setUp() so tests can call this from subTests when iterating overt TEST_DATA_SETS.
         """
-        self.options = {**asdict(test_data.options)}
+        self.options.update(options)
         self.world_setup()

--- a/apworld/brotato/test/__init__.py
+++ b/apworld/brotato/test/__init__.py
@@ -1,10 +1,26 @@
+from dataclasses import asdict
 from test.bases import WorldTestBase
 from typing import ClassVar
 
 from .. import BrotatoWorld
+from ._data_sets import TEST_DATA_SETS, BrotatoTestDataSet
 
 
 class BrotatoTestBase(WorldTestBase):
     game = "Brotato"
     world: BrotatoWorld  # type: ignore
     player: ClassVar[int] = 1
+
+    def _test_data_set_subtests(self):
+        for test_data in TEST_DATA_SETS:
+            with self.subTest(msg=test_data.test_name()):
+                self._run(test_data)
+                yield test_data
+
+    def _run(self, test_data: BrotatoTestDataSet):
+        """Setup the world using the options from the dataset.
+
+        We make this distinct from setUp() so tests can call this from subTests when iterating overt TEST_DATA_SETS.
+        """
+        self.options = {**asdict(test_data.options)}
+        self.world_setup()

--- a/apworld/brotato/test/_data_sets.py
+++ b/apworld/brotato/test/_data_sets.py
@@ -8,8 +8,8 @@ combinations.
 Currently, the test data sets are focused on testing the crate drop region creation and access rules, but there's no
 reason it couldn't be expanded to handle more in the future.
 """
-from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..Constants import (
     MAX_LEGENDARY_CRATE_DROP_GROUPS,
@@ -106,6 +106,10 @@ class BrotatoTestDataSet:
             name = options_str
 
         return name
+
+    @property
+    def options_dict(self) -> Dict[str, Any]:
+        return asdict(self.options)
 
 
 TEST_DATA_SETS: List[BrotatoTestDataSet] = [

--- a/apworld/brotato/test/_data_sets.py
+++ b/apworld/brotato/test/_data_sets.py
@@ -1,0 +1,306 @@
+"""Define test data for various Brotato unit tests.
+
+Test data consists of a set of options to create the test World with, and various expected results.
+
+Test classes can create subtests which run on each data set to check that generation works for different option
+combinations.
+
+Currently, the test data sets are focused on testing the crate drop region creation and access rules, but there's no
+reason it couldn't be expanded to handle more in the future.
+"""
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+from ..Constants import (
+    MAX_LEGENDARY_CRATE_DROP_GROUPS,
+    MAX_LEGENDARY_CRATE_DROPS,
+    MAX_NORMAL_CRATE_DROP_GROUPS,
+    MAX_NORMAL_CRATE_DROPS,
+    NUM_CHARACTERS,
+)
+
+
+@dataclass(frozen=True)
+class BrotatoTestOptions:
+    """Subset of the full options that we want to control for the test, with defaults.
+
+    This avoids needing to specify all the options for the dataclass, and makes using it in the tests slightly more
+    concise.
+    """
+
+    num_common_crate_drops: int
+    num_common_crate_drop_groups: int
+    num_legendary_crate_drops: int
+    num_legendary_crate_drop_groups: int
+    num_victories: int = 30
+
+
+@dataclass(frozen=True)
+class BrotatoTestExpectedResults:
+    # An int value means all regions have the same number of crates.
+    # A tuple of ints means region "Crate Group {i}" has number of crates in index [i]
+    num_common_crate_regions: int
+    common_crates_per_region: Union[int, Tuple[int, ...]]
+    num_legendary_crate_regions: int
+    legendary_crates_per_region: Union[int, Tuple[int, ...]]
+    wins_required_per_common_region: Tuple[int, ...]
+    wins_required_per_legendary_region: Tuple[int, ...]
+
+    def __post_init__(self):
+        """Validate the expected results to make sure the fields are consistent.
+
+        Currently, this just means checking that the expected number of regions matches the number of entries in the
+        crates per region fields.
+        """
+
+        if isinstance(self.common_crates_per_region, tuple):
+            num_common_crate_regions = len(self.common_crates_per_region)
+            if num_common_crate_regions != self.num_common_crate_regions:
+                raise ValueError(
+                    f"common_crates_per_region has {num_common_crate_regions} entries, expected "
+                    f"{self.num_common_crate_regions}."
+                )
+
+        if len(self.wins_required_per_common_region) != self.num_common_crate_regions:
+            num_win_entries = len(self.wins_required_per_common_region)
+            raise ValueError(
+                f"wins_required_per_common_region has {num_win_entries} entries, expected "
+                f"{self.num_common_crate_regions}."
+            )
+
+        if isinstance(self.legendary_crates_per_region, tuple):
+            num_legendary_crate_regions = len(self.legendary_crates_per_region)
+            if num_legendary_crate_regions != self.num_legendary_crate_regions:
+                raise ValueError(
+                    f"legendary_crates_per_region has {num_legendary_crate_regions} entries, expected "
+                    f"{self.num_legendary_crate_regions}."
+                )
+
+        if len(self.wins_required_per_legendary_region) != self.num_legendary_crate_regions:
+            num_win_entries = len(self.wins_required_per_legendary_region)
+            raise ValueError(
+                f"wins_required_per_legendary_region has {num_win_entries} entries, expected "
+                f"{self.num_legendary_crate_regions}."
+            )
+
+
+@dataclass(frozen=True)
+class BrotatoTestDataSet:
+    options: BrotatoTestOptions
+    expected_results: BrotatoTestExpectedResults
+    description: Optional[str] = None
+
+    def test_name(self) -> str:
+        options_str = ", ".join(
+            [
+                f"CD={self.options.num_common_crate_drops}",
+                f"CG={self.options.num_common_crate_drop_groups}",
+                f"LD={self.options.num_legendary_crate_drops}",
+                f"LG={self.options.num_legendary_crate_drop_groups}",
+                f"NV={self.options.num_victories}",
+            ]
+        )
+        if self.description:
+            name = f"{options_str} ({self.description})"
+        else:
+            name = options_str
+
+        return name
+
+
+TEST_DATA_SETS: List[BrotatoTestDataSet] = [
+    BrotatoTestDataSet(
+        description="Easily divisible, common and legendary same (25 crates)",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=25,
+            num_common_crate_drop_groups=5,
+            num_legendary_crate_drops=25,
+            num_legendary_crate_drop_groups=5,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=5,
+            common_crates_per_region=5,
+            num_legendary_crate_regions=5,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 6, 12, 18, 24),
+            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Easily divisible, common and legendary same (30 crates)",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=30,
+            num_common_crate_drop_groups=6,
+            num_legendary_crate_drops=30,
+            num_legendary_crate_drop_groups=6,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=6,
+            common_crates_per_region=5,
+            num_legendary_crate_regions=6,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 5, 10, 15, 20, 25),
+            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Easily divisible, common and legendary are different",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=20,
+            num_common_crate_drop_groups=2,
+            num_legendary_crate_drops=30,
+            num_legendary_crate_drop_groups=6,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=2,
+            common_crates_per_region=10,
+            num_legendary_crate_regions=6,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 15),
+            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Unequal groups",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=16,
+            num_common_crate_drop_groups=3,
+            num_legendary_crate_drops=16,
+            num_legendary_crate_drop_groups=3,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=3,
+            common_crates_per_region=(6, 5, 5),
+            num_legendary_crate_regions=3,
+            legendary_crates_per_region=(6, 5, 5),
+            wins_required_per_common_region=(0, 10, 20),
+            wins_required_per_legendary_region=(0, 10, 20),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Unequal groups, common and legendary are different",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=35,
+            num_common_crate_drop_groups=15,
+            num_legendary_crate_drops=25,
+            num_legendary_crate_drop_groups=5,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            # Five "3's" and ten "2's", because the drops don't evenly divide into the groups
+            num_common_crate_regions=15,
+            common_crates_per_region=tuple(([3] * 5) + ([2] * 10)),
+            num_legendary_crate_regions=5,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28),
+            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Max possible groups and crates, more groups than req. wins",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            # The number of groups will be set to 30 when generating.
+            num_common_crate_regions=30,
+            common_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
+            num_legendary_crate_regions=30,
+            legendary_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
+            # Every win will unlock a new crate drop group.
+            wins_required_per_common_region=tuple(range(30)),
+            wins_required_per_legendary_region=tuple(range(30)),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Max possible groups and crates",
+        options=BrotatoTestOptions(
+            num_victories=NUM_CHARACTERS,
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=NUM_CHARACTERS,
+            common_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
+            num_legendary_crate_regions=NUM_CHARACTERS,
+            legendary_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
+            # Every win will unlock a new crate drop group.
+            wins_required_per_common_region=tuple(range(MAX_NORMAL_CRATE_DROP_GROUPS)),
+            wins_required_per_legendary_region=tuple(range(MAX_LEGENDARY_CRATE_DROP_GROUPS)),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Max number of crates, one group",
+        options=BrotatoTestOptions(
+            num_victories=NUM_CHARACTERS,
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drop_groups=1,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=1,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=50,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=50,
+            # All the crates should be in the first group which is unlocked by default.
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="1 crate and 1 group",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=1,
+            num_common_crate_drop_groups=1,
+            num_legendary_crate_drops=1,
+            num_legendary_crate_drop_groups=1,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=1,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=1,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="2 crates, 1 group",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=2,
+            num_common_crate_drop_groups=1,
+            num_legendary_crate_drops=2,
+            num_legendary_crate_drop_groups=1,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=2,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=2,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
+    ),
+    BrotatoTestDataSet(
+        description="Max number of crates, 1 common group, 2 legendary groups",
+        options=BrotatoTestOptions(
+            num_common_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_common_crate_drop_groups=1,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=2,
+        ),
+        expected_results=BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=50,
+            num_legendary_crate_regions=2,
+            legendary_crates_per_region=25,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0, 15),
+        ),
+    ),
+]

--- a/apworld/brotato/test/test_brotato_world.py
+++ b/apworld/brotato/test/test_brotato_world.py
@@ -1,0 +1,34 @@
+from . import BrotatoTestBase
+from ._data_sets import BrotatoTestDataSet
+
+
+class TestBrotatoWorld(BrotatoTestBase):
+    """Test attributes on the BrotatoWorld instance directly."""
+
+    def test_common_loot_crate_groups_correct(self):
+        test_data: BrotatoTestDataSet
+        for test_data in self._test_data_set_subtests():
+            common_crate_groups = self.world.common_loot_crate_groups
+            assert len(common_crate_groups) == test_data.expected_results.num_common_crate_regions
+            for index, group in enumerate(common_crate_groups):
+                assert group.index == index + 1
+                if isinstance(test_data.expected_results.common_crates_per_region, int):
+                    assert group.num_crates == test_data.expected_results.common_crates_per_region
+                else:
+                    assert group.num_crates == test_data.expected_results.common_crates_per_region[index]
+
+                assert group.wins_to_unlock == test_data.expected_results.wins_required_per_common_region[index]
+
+    def test_legendary_loot_crate_groups_correct(self):
+        test_data: BrotatoTestDataSet
+        for test_data in self._test_data_set_subtests():
+            legendary_crate_groups = self.world.legendary_loot_crate_groups
+            assert len(legendary_crate_groups) == test_data.expected_results.num_legendary_crate_regions
+            for index, group in enumerate(legendary_crate_groups):
+                assert group.index == index + 1
+                if isinstance(test_data.expected_results.legendary_crates_per_region, int):
+                    assert group.num_crates == test_data.expected_results.legendary_crates_per_region
+                else:
+                    assert group.num_crates == test_data.expected_results.legendary_crates_per_region[index]
+
+                assert group.wins_to_unlock == test_data.expected_results.wins_required_per_legendary_region[index]

--- a/apworld/brotato/test/test_brotato_world.py
+++ b/apworld/brotato/test/test_brotato_world.py
@@ -1,9 +1,41 @@
+from typing import List, Tuple
+
 from . import BrotatoTestBase
 from ._data_sets import BrotatoTestDataSet
 
 
 class TestBrotatoWorld(BrotatoTestBase):
     """Test attributes on the BrotatoWorld instance directly."""
+
+    def test_waves_with_drops_correct(self):
+        # There's only 20 valid values for "Waves per Check" option, so we can test every possible value here.
+        option_and_expected: List[Tuple[int, List[int]]] = [
+            (1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+            (2, [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]),
+            (3, [3, 6, 9, 12, 15, 18]),
+            (4, [4, 8, 12, 16, 20]),
+            (5, [5, 10, 15, 20]),
+            (6, [6, 12, 18]),
+            (7, [7, 14]),
+            (8, [8, 16]),
+            (9, [9, 18]),
+            (10, [10, 20]),
+            (11, [11]),
+            (12, [12]),
+            (13, [13]),
+            (14, [14]),
+            (15, [15]),
+            (16, [16]),
+            (17, [17]),
+            (18, [18]),
+            (19, [19]),
+            (20, [20]),
+        ]
+        for option_value, expected_waves_with_checks in option_and_expected:
+            with self.subTest(msg=f"Waves per check = {option_value}"):
+                self._run({"waves_per_drop": option_value})
+                # Coerce to list so the types match
+                assert list(self.world.waves_with_checks) == expected_waves_with_checks
 
     def test_common_loot_crate_groups_correct(self):
         test_data: BrotatoTestDataSet

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -24,7 +24,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         total_possible_normal_crate_groups = MAX_NORMAL_CRATE_DROPS
         total_possible_legendary_crate_groups = MAX_LEGENDARY_CRATE_DROPS
         for test_data in self._test_data_set_subtests():
-            self._run(test_data)
+            self._run(test_data.options_dict)
             player_regions = self.multiworld.regions.region_cache[self.player]
             for common_region_idx in range(1, test_data.expected_results.num_common_crate_regions + 1):
                 expected_normal_crate_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
@@ -65,7 +65,7 @@ class TestBrotatoRegions(BrotatoTestBase):
 
     def test_crate_drop_regions_have_correct_locations(self):
         for test_data in self._test_data_set_subtests():
-            self._run(test_data)
+            self._run(test_data.options_dict)
             self._test_regions_have_correct_locations(
                 test_data.expected_results.common_crates_per_region,
                 test_data.expected_results.num_common_crate_regions,
@@ -89,7 +89,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         # run_won_item_name = ItemName.RUN_COMPLETE.value
         # run_won_item = self.world.create_item(run_won_item_name)
         for test_data in self._test_data_set_subtests():
-            self._run(test_data)
+            self._run(test_data.options_dict)
 
             self._test_regions_have_correct_access_rules(
                 test_data.expected_results.wins_required_per_common_region,
@@ -105,7 +105,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         duplication and no need to try and clear state within a test.
         """
         for test_data in self._test_data_set_subtests():
-            self._run(test_data)
+            self._run(test_data.options_dict)
 
             self._test_regions_have_correct_access_rules(
                 test_data.expected_results.wins_required_per_legendary_region,

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,14 +1,20 @@
 from dataclasses import asdict, dataclass
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from ..Constants import (
+    CHARACTERS,
     CRATE_DROP_GROUP_REGION_TEMPLATE,
     CRATE_DROP_LOCATION_TEMPLATE,
     LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
     LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
+    MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
+    MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
+    NUM_CHARACTERS,
+    RUN_COMPLETE_LOCATION_TEMPLATE,
 )
+from ..Items import ItemName
 from . import BrotatoTestBase
 
 
@@ -24,61 +30,136 @@ class _BrotatoTestOptions:
     num_common_crate_drop_groups: int
     num_legendary_crate_drops: int
     num_legendary_crate_drop_groups: int
+    num_victories: int = 30
 
 
 @dataclass(frozen=True)
 class _BrotatoTestExpectedResults:
     # An int value means all regions have the same number of crates.
     # A tuple of ints means region "Crate Group {i}" has number of crates in index [i]
+    num_common_crate_regions: int
     common_crates_per_region: Union[int, Tuple[int, ...]]
+    num_legendary_crate_regions: int
     legendary_crates_per_region: Union[int, Tuple[int, ...]]
+    wins_required_per_common_region: Tuple[int, ...]
+    wins_required_per_legendary_region: Tuple[int, ...]
+
+    def __post_init__(self):
+        """Validate the expected results to make sure the fields are consistent.
+
+        Currently, this just means checking that the expected number of regions matches the number of entries in the
+        crates per region fields.
+        """
+
+        if isinstance(self.common_crates_per_region, tuple):
+            num_common_crate_regions = len(self.common_crates_per_region)
+            if num_common_crate_regions != self.num_common_crate_regions:
+                raise ValueError(
+                    f"common_crates_per_region has {num_common_crate_regions} entries, expected "
+                    f"{self.num_common_crate_regions}."
+                )
+
+        if len(self.wins_required_per_common_region) != self.num_common_crate_regions:
+            num_win_entries = len(self.wins_required_per_common_region)
+            raise ValueError(
+                f"wins_required_per_common_region has {num_win_entries} entries, expected "
+                f"{self.num_common_crate_regions}."
+            )
+
+        if isinstance(self.legendary_crates_per_region, tuple):
+            num_legendary_crate_regions = len(self.legendary_crates_per_region)
+            if num_legendary_crate_regions != self.num_legendary_crate_regions:
+                raise ValueError(
+                    f"legendary_crates_per_region has {num_legendary_crate_regions} entries, expected "
+                    f"{self.num_legendary_crate_regions}."
+                )
+
+        if len(self.wins_required_per_legendary_region) != self.num_legendary_crate_regions:
+            num_win_entries = len(self.wins_required_per_legendary_region)
+            raise ValueError(
+                f"wins_required_per_legendary_region has {num_win_entries} entries, expected "
+                f"{self.num_legendary_crate_regions}."
+            )
 
 
 @dataclass(frozen=True)
 class _BrotatoTestDataSet:
     options: _BrotatoTestOptions
     expected_results: _BrotatoTestExpectedResults
+    description: Optional[str] = None
 
     def test_name(self) -> str:
-        return ", ".join(
+        options_str = ", ".join(
             [
-                str(self.options.num_common_crate_drops),
-                str(self.options.num_common_crate_drop_groups),
-                str(self.options.num_legendary_crate_drops),
-                str(self.options.num_legendary_crate_drop_groups),
+                f"CD={self.options.num_common_crate_drops}",
+                f"CG={self.options.num_common_crate_drop_groups}",
+                f"LD={self.options.num_legendary_crate_drops}",
+                f"LG={self.options.num_legendary_crate_drop_groups}",
+                f"NV={self.options.num_victories}",
             ]
         )
+        if self.description:
+            name = f"{options_str} ({self.description})"
+        else:
+            name = options_str
+
+        return name
 
 
 _TEST_DATA_SETS: List[_BrotatoTestDataSet] = [
     _BrotatoTestDataSet(
+        description="Easily divisible, common and legendary same (25 crates)",
         options=_BrotatoTestOptions(
             num_common_crate_drops=25,
             num_common_crate_drop_groups=5,
             num_legendary_crate_drops=25,
             num_legendary_crate_drop_groups=5,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=5, legendary_crates_per_region=5),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=5,
+            common_crates_per_region=5,
+            num_legendary_crate_regions=5,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 6, 12, 18, 24),
+            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="Easily divisible, common and legendary same (30 crates)",
         options=_BrotatoTestOptions(
             num_common_crate_drops=30,
             num_common_crate_drop_groups=6,
             num_legendary_crate_drops=30,
             num_legendary_crate_drop_groups=6,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=5, legendary_crates_per_region=5),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=6,
+            common_crates_per_region=5,
+            num_legendary_crate_regions=6,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 5, 10, 15, 20, 25),
+            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="Easily divisible, common and legendary are different",
         options=_BrotatoTestOptions(
             num_common_crate_drops=20,
             num_common_crate_drop_groups=2,
             num_legendary_crate_drops=30,
             num_legendary_crate_drop_groups=6,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=10, legendary_crates_per_region=5),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=2,
+            common_crates_per_region=10,
+            num_legendary_crate_regions=6,
+            legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 15),
+            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="Unequal groups",
         options=_BrotatoTestOptions(
             num_common_crate_drops=16,
             num_common_crate_drop_groups=3,
@@ -86,10 +167,16 @@ _TEST_DATA_SETS: List[_BrotatoTestDataSet] = [
             num_legendary_crate_drop_groups=3,
         ),
         expected_results=_BrotatoTestExpectedResults(
-            common_crates_per_region=(6, 5, 5), legendary_crates_per_region=(6, 5, 5)
+            num_common_crate_regions=3,
+            common_crates_per_region=(6, 5, 5),
+            num_legendary_crate_regions=3,
+            legendary_crates_per_region=(6, 5, 5),
+            wins_required_per_common_region=(0, 10, 20),
+            wins_required_per_legendary_region=(0, 10, 20),
         ),
     ),
     _BrotatoTestDataSet(
+        description="Unequal groups, common and legendary are different",
         options=_BrotatoTestOptions(
             num_common_crate_drops=35,
             num_common_crate_drop_groups=15,
@@ -98,61 +185,128 @@ _TEST_DATA_SETS: List[_BrotatoTestDataSet] = [
         ),
         expected_results=_BrotatoTestExpectedResults(
             # Five "3's" and ten "2's", because the drops don't evenly divide into the groups
-            common_crates_per_region=(*([3] * 5), *([2] * 10)),
+            num_common_crate_regions=15,
+            common_crates_per_region=tuple(([3] * 5) + ([2] * 10)),
+            num_legendary_crate_regions=5,
             legendary_crates_per_region=5,
+            wins_required_per_common_region=(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28),
+            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
         ),
     ),
     _BrotatoTestDataSet(
+        description="Max possible groups and crates, more groups than req. wins",
         options=_BrotatoTestOptions(
-            num_common_crate_drops=50,
-            num_common_crate_drop_groups=50,
-            num_legendary_crate_drops=50,
-            num_legendary_crate_drop_groups=50,
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=1, legendary_crates_per_region=1),
+        expected_results=_BrotatoTestExpectedResults(
+            # The number of groups will be set to 30 when generating.
+            num_common_crate_regions=30,
+            common_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
+            num_legendary_crate_regions=30,
+            legendary_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
+            # Every win will unlock a new crate drop group.
+            wins_required_per_common_region=tuple(range(30)),
+            wins_required_per_legendary_region=tuple(range(30)),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="Max possible groups and crates",
         options=_BrotatoTestOptions(
-            num_common_crate_drops=50,
+            num_victories=NUM_CHARACTERS,
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
+            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
+        ),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=NUM_CHARACTERS,
+            common_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
+            num_legendary_crate_regions=NUM_CHARACTERS,
+            legendary_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
+            # Every win will unlock a new crate drop group.
+            wins_required_per_common_region=tuple(range(MAX_NORMAL_CRATE_DROP_GROUPS)),
+            wins_required_per_legendary_region=tuple(range(MAX_LEGENDARY_CRATE_DROP_GROUPS)),
+        ),
+    ),
+    _BrotatoTestDataSet(
+        description="Max number of crates, one group",
+        options=_BrotatoTestOptions(
+            num_victories=NUM_CHARACTERS,
+            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
             num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=50,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=50, legendary_crates_per_region=50),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=50,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=50,
+            # All the crates should be in the first group which is unlocked by default.
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="1 crate and 1 group",
         options=_BrotatoTestOptions(
             num_common_crate_drops=1,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=1,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=1, legendary_crates_per_region=1),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=1,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=1,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="2 crates, 1 group",
         options=_BrotatoTestOptions(
             num_common_crate_drops=2,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=2,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=2, legendary_crates_per_region=2),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=2,
+            num_legendary_crate_regions=1,
+            legendary_crates_per_region=2,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0,),
+        ),
     ),
     _BrotatoTestDataSet(
+        description="Max number of crates, 1 common group, 2 legendary groups",
         options=_BrotatoTestOptions(
-            num_common_crate_drops=50,
+            num_common_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=50,
+            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_legendary_crate_drop_groups=2,
         ),
-        expected_results=_BrotatoTestExpectedResults(common_crates_per_region=50, legendary_crates_per_region=25),
+        expected_results=_BrotatoTestExpectedResults(
+            num_common_crate_regions=1,
+            common_crates_per_region=50,
+            num_legendary_crate_regions=2,
+            legendary_crates_per_region=25,
+            wins_required_per_common_region=(0,),
+            wins_required_per_legendary_region=(0, 15),
+        ),
     ),
 ]
 
 
 class TestBrotatoRegions(BrotatoTestBase):
     def _run(self, test_data: _BrotatoTestDataSet):
-        self.options = asdict(test_data.options)
+        self.options = {**asdict(test_data.options)}
         self.world_setup()
 
     def test_correct_number_of_crate_drop_regions_created(self):
@@ -167,14 +321,14 @@ class TestBrotatoRegions(BrotatoTestBase):
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
                 player_regions = self.multiworld.regions.region_cache[self.player]
-                for common_region_idx in range(1, test_data.options.num_common_crate_drop_groups + 1):
+                for common_region_idx in range(1, test_data.expected_results.num_common_crate_regions + 1):
                     expected_normal_crate_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
                     self.assertIn(
                         expected_normal_crate_group,
                         player_regions,
                         msg=f"Did not find expected normal loot crate region {expected_normal_crate_group}.",
                     )
-                for legendary_region_idx in range(1, test_data.options.num_legendary_crate_drop_groups + 1):
+                for legendary_region_idx in range(1, test_data.expected_results.num_legendary_crate_regions + 1):
                     expected_legendary_crate_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(
                         num=legendary_region_idx
                     )
@@ -210,24 +364,91 @@ class TestBrotatoRegions(BrotatoTestBase):
                 self._run(test_data)
                 self._test_regions_have_correct_locations(
                     test_data.expected_results.common_crates_per_region,
-                    test_data.options.num_common_crate_drop_groups,
+                    test_data.expected_results.num_common_crate_regions,
                     CRATE_DROP_LOCATION_TEMPLATE,
                     CRATE_DROP_GROUP_REGION_TEMPLATE,
                 )
                 self._test_regions_have_correct_locations(
                     test_data.expected_results.legendary_crates_per_region,
-                    test_data.options.num_legendary_crate_drop_groups,
+                    test_data.expected_results.num_legendary_crate_regions,
                     LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
                     LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
                 )
 
-    def test_crate_drop_region_access_rules_correct(self):
+    def test_normal_crate_drop_region_have_correct_access_rules(self):
+        """Check that each of the normal loot crate drop regions is only unlocked after enough wins are achieved.
+
+        This and the legendary loot crate region tests are separate since they both need to incrementally update the
+        state and check region access at each step. Splitting the tests, with a common private test method, means less
+        duplication and no need to try and clear state within a test.
+        """
+        # run_won_item_name = ItemName.RUN_COMPLETE.value
+        # run_won_item = self.world.create_item(run_won_item_name)
         for test_data in _TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
-                player_regions = self.multiworld.regions.region_cache[self.player]
-                for region in range(test_data.common_crate_regions):
-                    pass
+
+                self._test_regions_have_correct_access_rules(
+                    test_data.expected_results.wins_required_per_common_region,
+                    test_data.expected_results.num_common_crate_regions,
+                    CRATE_DROP_GROUP_REGION_TEMPLATE,
+                )
+
+    def test_legendary_crate_drop_region_have_correct_access_rules(self):
+        """Check that each of the legendary loot crate drop regions is only unlocked after enough wins are achieved.
+
+        This and the normal loot crate region tests are separate since they both need to incrementally update the
+        state and check region access at each step. Splitting the tests, with a common private test method, means less
+        duplication and no need to try and clear state within a test.
+        """
+        # run_won_item_name = ItemName.RUN_COMPLETE.value
+        # run_won_item = self.world.create_item(run_won_item_name)
+        for test_data in _TEST_DATA_SETS:
+            with self.subTest(msg=test_data.test_name()):
+                self._run(test_data)
+
+                self._test_regions_have_correct_access_rules(
+                    test_data.expected_results.wins_required_per_legendary_region,
+                    test_data.expected_results.num_legendary_crate_regions,
+                    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
+                )
+
+    def _test_regions_have_correct_access_rules(
+        self, wins_per_region: Tuple[int, ...], num_regions: int, region_template: str
+    ):
+        """Shared test logic for the crate drop region access rules tests."""
+
+        run_won_item_name = ItemName.RUN_COMPLETE.value
+        run_won_item = self.world.create_item(run_won_item_name)
+        character_index = 0
+        for region_idx, num_wins_to_reach in zip(range(1, num_regions + 1), wins_per_region):
+            region_name = region_template.format(num=region_idx)
+
+            # Add Run Won items by getting each character's Run Won location in order
+            num_wins = self.count(run_won_item_name)
+            while num_wins < num_wins_to_reach:
+                # Make sure the region isn't reachable too early
+                assert not self.can_reach_region(
+                    region_name
+                ), f'Region "{region_name}" should be unreachable without {num_wins_to_reach} wins, have {num_wins}.'
+
+                next_character_won = CHARACTERS[character_index]
+                character_index += 1
+                next_win_location = self.world.get_location(
+                    RUN_COMPLETE_LOCATION_TEMPLATE.format(char=next_character_won)
+                )
+                old_num_wins = self.multiworld.state.count(run_won_item_name, self.player)
+                # Set event=True so the state doesn't try to collect more wins and throw off our tests
+                self.multiworld.state.collect(run_won_item, event=True, location=next_win_location)
+                num_wins = self.multiworld.state.count(run_won_item_name, self.player)
+                # Sanity check that the state updated as we intend it to.
+                assert (
+                    num_wins == old_num_wins + 1
+                ), "State added more than 1 'Run Won' item, this is a test implementation error."
+
+            assert self.can_reach_region(
+                region_name
+            ), f"Could not reach region {region_name} with {num_wins_to_reach} wins."
 
     def _test_regions_have_correct_locations(
         self,

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,24 +1,139 @@
-from ..Constants import CRATE_DROP_GROUP_REGION_TEMPLATE
+from typing import List, Tuple, NamedTuple, Union
+from ..Constants import (
+    CRATE_DROP_GROUP_REGION_TEMPLATE,
+    MAX_NORMAL_CRATE_DROPS,
+    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
+    MAX_LEGENDARY_CRATE_DROPS,
+    CRATE_DROP_LOCATION_TEMPLATE,
+    LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
+)
 from . import BrotatoTestBase
 
 
+class _OptionsAndResults(NamedTuple):
+    common_crate_locations: int
+    common_crate_regions: int
+    legendary_crate_locations: int
+    legendary_crate_regions: int
+
+    # An int value means all regions have the same number of crates.
+    # A tuple of ints means region "Crate Group {i}" has number of crates in index [i]
+    common_crates_per_region: Union[int, Tuple[int, ...]]
+    legendary_crates_per_region: Union[int, Tuple[int, ...]]
+
+
+_OPTION_SETS: List[_OptionsAndResults] = [
+    _OptionsAndResults(25, 5, 25, 5, 5, 5),
+    _OptionsAndResults(30, 6, 30, 6, 5, 5),
+    _OptionsAndResults(20, 2, 30, 6, 10, 5),
+    _OptionsAndResults(16, 3, 16, 3, [6, 5, 5], [6, 5, 5]),
+    _OptionsAndResults(35, 15, 25, 5, [7] + [2] * 14, 5),
+    _OptionsAndResults(50, 50, 50, 50, 1, 1),
+    _OptionsAndResults(50, 1, 50, 1, 50, 50),
+    _OptionsAndResults(1, 1, 1, 1, 1, 1),
+    _OptionsAndResults(2, 1, 2, 1, 2, 2),
+    _OptionsAndResults(50, 1, 50, 2, 50, 25),
+]
+
+
 class TestBrotatoRegions(BrotatoTestBase):
-    def _run(
-        self,
-        num_common_crate_drops: int,
-        num_common_crate_drop_groups: int,
-        num_legendary_crate_drops: int,
-        num_legendary_crate_drop_groups: int,
-    ):
+    def _run(self, options: _OptionsAndResults):
         self.options = {
             "starting_characters": 1,  # Just use the default five
-            "num_common_crate_drops": num_common_crate_drops,
-            "num_common_crate_drop_groups": num_common_crate_drop_groups,
-            "num_legendary_crate_drops": num_legendary_crate_drops,
-            "num_legendary_crate_drop_groups": num_legendary_crate_drop_groups,
+            "num_common_crate_drops": options.common_crate_locations,
+            "num_common_crate_drop_groups": options.common_crate_regions,
+            "num_legendary_crate_drops": options.legendary_crate_locations,
+            "num_legendary_crate_drop_groups": options.legendary_crate_regions,
         }
         self.world_setup()
 
-    def test_groups_have_correct_number_crates(self):
-        self._run(25, 5, 25, 5)
-        assert self.can_reach_region(CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=1))
+    def test_correct_number_of_crate_drop_regions_created(self):
+        """Test that only the location groups needed are created.
+
+        It is possible to have one group for every loot crate, but if we have 25 crates and 5 groups, then there should
+        only be 5 regions for normal crates and legendary crates.
+        """
+        total_possible_normal_crate_groups = MAX_NORMAL_CRATE_DROPS
+        total_possible_legendary_crate_groups = MAX_LEGENDARY_CRATE_DROPS
+        for options_set in _OPTION_SETS:
+            with self.subTest(options_and_results=options_set):
+                self._run(options_set)
+                player_regions = self.multiworld.regions.region_cache[self.player]
+
+                for common_region_idx in range(1, options_set.common_crate_regions + 1):
+                    expected_normal_crate_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
+                    self.assertIn(
+                        expected_normal_crate_group,
+                        player_regions,
+                        msg=f"Did not find expected normal loot crate region {expected_normal_crate_group}.",
+                    )
+                for legendary_region_idx in range(1, options_set.legendary_crate_regions + 1):
+                    expected_legendary_crate_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(
+                        num=legendary_region_idx
+                    )
+                    self.assertIn(
+                        expected_legendary_crate_group,
+                        player_regions,
+                        msg=f"Did not find expected legendary loot crate region {expected_legendary_crate_group}.",
+                    )
+
+                for common_region_idx in range(
+                    options_set.common_crate_regions + 1, total_possible_normal_crate_groups + 1
+                ):
+                    expected_missing_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
+                    self.assertNotIn(
+                        expected_missing_group,
+                        player_regions,
+                        msg=f"Normal loot crate region {expected_missing_group} should not have been created.",
+                    )
+
+                for legendary_region_idx in range(
+                    options_set.legendary_crate_regions + 1, total_possible_legendary_crate_groups
+                ):
+                    expected_missing_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=legendary_region_idx)
+                    self.assertNotIn(
+                        expected_missing_group,
+                        player_regions,
+                        msg=f"Legendary loot crate region {expected_missing_group} should not have been created.",
+                    )
+
+    def test_crate_drop_regions_have_correct_locations(self):
+        for options_set in _OPTION_SETS:
+            with self.subTest(options_and_results=options_set):
+                self._run(options_set)
+                self._test_regions_have_correct_locations(
+                    options_set.common_crates_per_region,
+                    options_set.common_crate_regions,
+                    CRATE_DROP_LOCATION_TEMPLATE,
+                    CRATE_DROP_GROUP_REGION_TEMPLATE,
+                )
+                self._test_regions_have_correct_locations(
+                    options_set.legendary_crates_per_region,
+                    options_set.legendary_crate_regions,
+                    LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
+                    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
+                )
+
+    def _test_regions_have_correct_locations(
+        self,
+        locations_per_region: Union[int, Tuple[int, ...]],
+        num_regions: int,
+        location_template: str,
+        region_template: str,
+    ):
+        player_regions = self.multiworld.regions.region_cache[self.player]
+        if isinstance(locations_per_region, int):
+            num_locations_per_region = tuple([locations_per_region] * num_regions)
+        else:
+            num_locations_per_region = locations_per_region
+
+        location_counter = 1
+        for region_idx in range(num_regions):
+            num_locations = num_locations_per_region[region_idx]
+            expected_location_names = [
+                location_template.format(num=i) for i in range(location_counter, location_counter + num_locations)
+            ]
+            location_counter += num_locations
+            region = player_regions[region_template.format(num=region_idx + 1)]
+            actual_location_names = [loc.name for loc in region.locations]
+            self.assertListEqual(actual_location_names, expected_location_names)

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,0 +1,24 @@
+from ..Constants import CRATE_DROP_GROUP_REGION_TEMPLATE
+from . import BrotatoTestBase
+
+
+class TestBrotatoRegions(BrotatoTestBase):
+    def _run(
+        self,
+        num_common_crate_drops: int,
+        num_common_crate_drop_groups: int,
+        num_legendary_crate_drops: int,
+        num_legendary_crate_drop_groups: int,
+    ):
+        self.options = {
+            "starting_characters": 1,  # Just use the default five
+            "num_common_crate_drops": num_common_crate_drops,
+            "num_common_crate_drop_groups": num_common_crate_drop_groups,
+            "num_legendary_crate_drops": num_legendary_crate_drops,
+            "num_legendary_crate_drop_groups": num_legendary_crate_drop_groups,
+        }
+        self.world_setup()
+
+    def test_groups_have_correct_number_crates(self):
+        self._run(25, 5, 25, 5)
+        assert self.can_reach_region(CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=1))

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,5 +1,5 @@
-from dataclasses import asdict, dataclass
-from typing import List, Optional, Tuple, Union
+from dataclasses import asdict
+from typing import Tuple, Union
 
 from ..Constants import (
     CHARACTERS,
@@ -7,305 +7,17 @@ from ..Constants import (
     CRATE_DROP_LOCATION_TEMPLATE,
     LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
     LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
-    MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
-    MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
-    NUM_CHARACTERS,
     RUN_COMPLETE_LOCATION_TEMPLATE,
 )
 from ..Items import ItemName
 from . import BrotatoTestBase
-
-
-@dataclass(frozen=True)
-class _BrotatoTestOptions:
-    """Subset of the full options that we want to control for the test, with defaults.
-
-    This avoids needing to specify all the options for the dataclass, and makes using it in the tests slightly more
-    concise.
-    """
-
-    num_common_crate_drops: int
-    num_common_crate_drop_groups: int
-    num_legendary_crate_drops: int
-    num_legendary_crate_drop_groups: int
-    num_victories: int = 30
-
-
-@dataclass(frozen=True)
-class _BrotatoTestExpectedResults:
-    # An int value means all regions have the same number of crates.
-    # A tuple of ints means region "Crate Group {i}" has number of crates in index [i]
-    num_common_crate_regions: int
-    common_crates_per_region: Union[int, Tuple[int, ...]]
-    num_legendary_crate_regions: int
-    legendary_crates_per_region: Union[int, Tuple[int, ...]]
-    wins_required_per_common_region: Tuple[int, ...]
-    wins_required_per_legendary_region: Tuple[int, ...]
-
-    def __post_init__(self):
-        """Validate the expected results to make sure the fields are consistent.
-
-        Currently, this just means checking that the expected number of regions matches the number of entries in the
-        crates per region fields.
-        """
-
-        if isinstance(self.common_crates_per_region, tuple):
-            num_common_crate_regions = len(self.common_crates_per_region)
-            if num_common_crate_regions != self.num_common_crate_regions:
-                raise ValueError(
-                    f"common_crates_per_region has {num_common_crate_regions} entries, expected "
-                    f"{self.num_common_crate_regions}."
-                )
-
-        if len(self.wins_required_per_common_region) != self.num_common_crate_regions:
-            num_win_entries = len(self.wins_required_per_common_region)
-            raise ValueError(
-                f"wins_required_per_common_region has {num_win_entries} entries, expected "
-                f"{self.num_common_crate_regions}."
-            )
-
-        if isinstance(self.legendary_crates_per_region, tuple):
-            num_legendary_crate_regions = len(self.legendary_crates_per_region)
-            if num_legendary_crate_regions != self.num_legendary_crate_regions:
-                raise ValueError(
-                    f"legendary_crates_per_region has {num_legendary_crate_regions} entries, expected "
-                    f"{self.num_legendary_crate_regions}."
-                )
-
-        if len(self.wins_required_per_legendary_region) != self.num_legendary_crate_regions:
-            num_win_entries = len(self.wins_required_per_legendary_region)
-            raise ValueError(
-                f"wins_required_per_legendary_region has {num_win_entries} entries, expected "
-                f"{self.num_legendary_crate_regions}."
-            )
-
-
-@dataclass(frozen=True)
-class _BrotatoTestDataSet:
-    options: _BrotatoTestOptions
-    expected_results: _BrotatoTestExpectedResults
-    description: Optional[str] = None
-
-    def test_name(self) -> str:
-        options_str = ", ".join(
-            [
-                f"CD={self.options.num_common_crate_drops}",
-                f"CG={self.options.num_common_crate_drop_groups}",
-                f"LD={self.options.num_legendary_crate_drops}",
-                f"LG={self.options.num_legendary_crate_drop_groups}",
-                f"NV={self.options.num_victories}",
-            ]
-        )
-        if self.description:
-            name = f"{options_str} ({self.description})"
-        else:
-            name = options_str
-
-        return name
-
-
-_TEST_DATA_SETS: List[_BrotatoTestDataSet] = [
-    _BrotatoTestDataSet(
-        description="Easily divisible, common and legendary same (25 crates)",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=25,
-            num_common_crate_drop_groups=5,
-            num_legendary_crate_drops=25,
-            num_legendary_crate_drop_groups=5,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=5,
-            common_crates_per_region=5,
-            num_legendary_crate_regions=5,
-            legendary_crates_per_region=5,
-            wins_required_per_common_region=(0, 6, 12, 18, 24),
-            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Easily divisible, common and legendary same (30 crates)",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=30,
-            num_common_crate_drop_groups=6,
-            num_legendary_crate_drops=30,
-            num_legendary_crate_drop_groups=6,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=6,
-            common_crates_per_region=5,
-            num_legendary_crate_regions=6,
-            legendary_crates_per_region=5,
-            wins_required_per_common_region=(0, 5, 10, 15, 20, 25),
-            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Easily divisible, common and legendary are different",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=20,
-            num_common_crate_drop_groups=2,
-            num_legendary_crate_drops=30,
-            num_legendary_crate_drop_groups=6,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=2,
-            common_crates_per_region=10,
-            num_legendary_crate_regions=6,
-            legendary_crates_per_region=5,
-            wins_required_per_common_region=(0, 15),
-            wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Unequal groups",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=16,
-            num_common_crate_drop_groups=3,
-            num_legendary_crate_drops=16,
-            num_legendary_crate_drop_groups=3,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=3,
-            common_crates_per_region=(6, 5, 5),
-            num_legendary_crate_regions=3,
-            legendary_crates_per_region=(6, 5, 5),
-            wins_required_per_common_region=(0, 10, 20),
-            wins_required_per_legendary_region=(0, 10, 20),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Unequal groups, common and legendary are different",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=35,
-            num_common_crate_drop_groups=15,
-            num_legendary_crate_drops=25,
-            num_legendary_crate_drop_groups=5,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            # Five "3's" and ten "2's", because the drops don't evenly divide into the groups
-            num_common_crate_regions=15,
-            common_crates_per_region=tuple(([3] * 5) + ([2] * 10)),
-            num_legendary_crate_regions=5,
-            legendary_crates_per_region=5,
-            wins_required_per_common_region=(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28),
-            wins_required_per_legendary_region=(0, 6, 12, 18, 24),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Max possible groups and crates, more groups than req. wins",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
-            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
-            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            # The number of groups will be set to 30 when generating.
-            num_common_crate_regions=30,
-            common_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
-            num_legendary_crate_regions=30,
-            legendary_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
-            # Every win will unlock a new crate drop group.
-            wins_required_per_common_region=tuple(range(30)),
-            wins_required_per_legendary_region=tuple(range(30)),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Max possible groups and crates",
-        options=_BrotatoTestOptions(
-            num_victories=NUM_CHARACTERS,
-            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
-            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
-            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=NUM_CHARACTERS,
-            common_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
-            num_legendary_crate_regions=NUM_CHARACTERS,
-            legendary_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
-            # Every win will unlock a new crate drop group.
-            wins_required_per_common_region=tuple(range(MAX_NORMAL_CRATE_DROP_GROUPS)),
-            wins_required_per_legendary_region=tuple(range(MAX_LEGENDARY_CRATE_DROP_GROUPS)),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Max number of crates, one group",
-        options=_BrotatoTestOptions(
-            num_victories=NUM_CHARACTERS,
-            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
-            num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_legendary_crate_drop_groups=1,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=1,
-            common_crates_per_region=50,
-            num_legendary_crate_regions=1,
-            legendary_crates_per_region=50,
-            # All the crates should be in the first group which is unlocked by default.
-            wins_required_per_common_region=(0,),
-            wins_required_per_legendary_region=(0,),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="1 crate and 1 group",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=1,
-            num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=1,
-            num_legendary_crate_drop_groups=1,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=1,
-            common_crates_per_region=1,
-            num_legendary_crate_regions=1,
-            legendary_crates_per_region=1,
-            wins_required_per_common_region=(0,),
-            wins_required_per_legendary_region=(0,),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="2 crates, 1 group",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=2,
-            num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=2,
-            num_legendary_crate_drop_groups=1,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=1,
-            common_crates_per_region=2,
-            num_legendary_crate_regions=1,
-            legendary_crates_per_region=2,
-            wins_required_per_common_region=(0,),
-            wins_required_per_legendary_region=(0,),
-        ),
-    ),
-    _BrotatoTestDataSet(
-        description="Max number of crates, 1 common group, 2 legendary groups",
-        options=_BrotatoTestOptions(
-            num_common_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_common_crate_drop_groups=1,
-            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_legendary_crate_drop_groups=2,
-        ),
-        expected_results=_BrotatoTestExpectedResults(
-            num_common_crate_regions=1,
-            common_crates_per_region=50,
-            num_legendary_crate_regions=2,
-            legendary_crates_per_region=25,
-            wins_required_per_common_region=(0,),
-            wins_required_per_legendary_region=(0, 15),
-        ),
-    ),
-]
+from ._data_sets import TEST_DATA_SETS, BrotatoTestDataSet
 
 
 class TestBrotatoRegions(BrotatoTestBase):
-    def _run(self, test_data: _BrotatoTestDataSet):
+    def _run(self, test_data: BrotatoTestDataSet):
         self.options = {**asdict(test_data.options)}
         self.world_setup()
 
@@ -317,7 +29,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         """
         total_possible_normal_crate_groups = MAX_NORMAL_CRATE_DROPS
         total_possible_legendary_crate_groups = MAX_LEGENDARY_CRATE_DROPS
-        for test_data in _TEST_DATA_SETS:
+        for test_data in TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
                 player_regions = self.multiworld.regions.region_cache[self.player]
@@ -359,7 +71,7 @@ class TestBrotatoRegions(BrotatoTestBase):
                     )
 
     def test_crate_drop_regions_have_correct_locations(self):
-        for test_data in _TEST_DATA_SETS:
+        for test_data in TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
                 self._test_regions_have_correct_locations(
@@ -384,7 +96,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         """
         # run_won_item_name = ItemName.RUN_COMPLETE.value
         # run_won_item = self.world.create_item(run_won_item_name)
-        for test_data in _TEST_DATA_SETS:
+        for test_data in TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
 
@@ -403,7 +115,7 @@ class TestBrotatoRegions(BrotatoTestBase):
         """
         # run_won_item_name = ItemName.RUN_COMPLETE.value
         # run_won_item = self.world.create_item(run_won_item_name)
-        for test_data in _TEST_DATA_SETS:
+        for test_data in TEST_DATA_SETS:
             with self.subTest(msg=test_data.test_name()):
                 self._run(test_data)
 

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from typing import Tuple, Union
 
 from ..Constants import (
@@ -13,14 +12,9 @@ from ..Constants import (
 )
 from ..Items import ItemName
 from . import BrotatoTestBase
-from ._data_sets import TEST_DATA_SETS, BrotatoTestDataSet
 
 
 class TestBrotatoRegions(BrotatoTestBase):
-    def _run(self, test_data: BrotatoTestDataSet):
-        self.options = {**asdict(test_data.options)}
-        self.world_setup()
-
     def test_correct_number_of_crate_drop_regions_created(self):
         """Test that only the location groups needed are created.
 
@@ -29,63 +23,61 @@ class TestBrotatoRegions(BrotatoTestBase):
         """
         total_possible_normal_crate_groups = MAX_NORMAL_CRATE_DROPS
         total_possible_legendary_crate_groups = MAX_LEGENDARY_CRATE_DROPS
-        for test_data in TEST_DATA_SETS:
-            with self.subTest(msg=test_data.test_name()):
-                self._run(test_data)
-                player_regions = self.multiworld.regions.region_cache[self.player]
-                for common_region_idx in range(1, test_data.expected_results.num_common_crate_regions + 1):
-                    expected_normal_crate_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
-                    self.assertIn(
-                        expected_normal_crate_group,
-                        player_regions,
-                        msg=f"Did not find expected normal loot crate region {expected_normal_crate_group}.",
-                    )
-                for legendary_region_idx in range(1, test_data.expected_results.num_legendary_crate_regions + 1):
-                    expected_legendary_crate_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(
-                        num=legendary_region_idx
-                    )
-                    self.assertIn(
-                        expected_legendary_crate_group,
-                        player_regions,
-                        msg=f"Did not find expected legendary loot crate region {expected_legendary_crate_group}.",
-                    )
+        for test_data in self._test_data_set_subtests():
+            self._run(test_data)
+            player_regions = self.multiworld.regions.region_cache[self.player]
+            for common_region_idx in range(1, test_data.expected_results.num_common_crate_regions + 1):
+                expected_normal_crate_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
+                self.assertIn(
+                    expected_normal_crate_group,
+                    player_regions,
+                    msg=f"Did not find expected normal loot crate region {expected_normal_crate_group}.",
+                )
+            for legendary_region_idx in range(1, test_data.expected_results.num_legendary_crate_regions + 1):
+                expected_legendary_crate_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(
+                    num=legendary_region_idx
+                )
+                self.assertIn(
+                    expected_legendary_crate_group,
+                    player_regions,
+                    msg=f"Did not find expected legendary loot crate region {expected_legendary_crate_group}.",
+                )
 
-                for common_region_idx in range(
-                    test_data.options.num_common_crate_drop_groups + 1, total_possible_normal_crate_groups + 1
-                ):
-                    expected_missing_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
-                    self.assertNotIn(
-                        expected_missing_group,
-                        player_regions,
-                        msg=f"Normal loot crate region {expected_missing_group} should not have been created.",
-                    )
+            for common_region_idx in range(
+                test_data.options.num_common_crate_drop_groups + 1, total_possible_normal_crate_groups + 1
+            ):
+                expected_missing_group = CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=common_region_idx)
+                self.assertNotIn(
+                    expected_missing_group,
+                    player_regions,
+                    msg=f"Normal loot crate region {expected_missing_group} should not have been created.",
+                )
 
-                for legendary_region_idx in range(
-                    test_data.options.num_legendary_crate_drop_groups + 1, total_possible_legendary_crate_groups
-                ):
-                    expected_missing_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=legendary_region_idx)
-                    self.assertNotIn(
-                        expected_missing_group,
-                        player_regions,
-                        msg=f"Legendary loot crate region {expected_missing_group} should not have been created.",
-                    )
+            for legendary_region_idx in range(
+                test_data.options.num_legendary_crate_drop_groups + 1, total_possible_legendary_crate_groups
+            ):
+                expected_missing_group = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE.format(num=legendary_region_idx)
+                self.assertNotIn(
+                    expected_missing_group,
+                    player_regions,
+                    msg=f"Legendary loot crate region {expected_missing_group} should not have been created.",
+                )
 
     def test_crate_drop_regions_have_correct_locations(self):
-        for test_data in TEST_DATA_SETS:
-            with self.subTest(msg=test_data.test_name()):
-                self._run(test_data)
-                self._test_regions_have_correct_locations(
-                    test_data.expected_results.common_crates_per_region,
-                    test_data.expected_results.num_common_crate_regions,
-                    CRATE_DROP_LOCATION_TEMPLATE,
-                    CRATE_DROP_GROUP_REGION_TEMPLATE,
-                )
-                self._test_regions_have_correct_locations(
-                    test_data.expected_results.legendary_crates_per_region,
-                    test_data.expected_results.num_legendary_crate_regions,
-                    LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
-                    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
-                )
+        for test_data in self._test_data_set_subtests():
+            self._run(test_data)
+            self._test_regions_have_correct_locations(
+                test_data.expected_results.common_crates_per_region,
+                test_data.expected_results.num_common_crate_regions,
+                CRATE_DROP_LOCATION_TEMPLATE,
+                CRATE_DROP_GROUP_REGION_TEMPLATE,
+            )
+            self._test_regions_have_correct_locations(
+                test_data.expected_results.legendary_crates_per_region,
+                test_data.expected_results.num_legendary_crate_regions,
+                LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE,
+                LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
+            )
 
     def test_normal_crate_drop_region_have_correct_access_rules(self):
         """Check that each of the normal loot crate drop regions is only unlocked after enough wins are achieved.
@@ -96,15 +88,14 @@ class TestBrotatoRegions(BrotatoTestBase):
         """
         # run_won_item_name = ItemName.RUN_COMPLETE.value
         # run_won_item = self.world.create_item(run_won_item_name)
-        for test_data in TEST_DATA_SETS:
-            with self.subTest(msg=test_data.test_name()):
-                self._run(test_data)
+        for test_data in self._test_data_set_subtests():
+            self._run(test_data)
 
-                self._test_regions_have_correct_access_rules(
-                    test_data.expected_results.wins_required_per_common_region,
-                    test_data.expected_results.num_common_crate_regions,
-                    CRATE_DROP_GROUP_REGION_TEMPLATE,
-                )
+            self._test_regions_have_correct_access_rules(
+                test_data.expected_results.wins_required_per_common_region,
+                test_data.expected_results.num_common_crate_regions,
+                CRATE_DROP_GROUP_REGION_TEMPLATE,
+            )
 
     def test_legendary_crate_drop_region_have_correct_access_rules(self):
         """Check that each of the legendary loot crate drop regions is only unlocked after enough wins are achieved.
@@ -113,17 +104,14 @@ class TestBrotatoRegions(BrotatoTestBase):
         state and check region access at each step. Splitting the tests, with a common private test method, means less
         duplication and no need to try and clear state within a test.
         """
-        # run_won_item_name = ItemName.RUN_COMPLETE.value
-        # run_won_item = self.world.create_item(run_won_item_name)
-        for test_data in TEST_DATA_SETS:
-            with self.subTest(msg=test_data.test_name()):
-                self._run(test_data)
+        for test_data in self._test_data_set_subtests():
+            self._run(test_data)
 
-                self._test_regions_have_correct_access_rules(
-                    test_data.expected_results.wins_required_per_legendary_region,
-                    test_data.expected_results.num_legendary_crate_regions,
-                    LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
-                )
+            self._test_regions_have_correct_access_rules(
+                test_data.expected_results.wins_required_per_legendary_region,
+                test_data.expected_results.num_legendary_crate_regions,
+                LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
+            )
 
     def _test_regions_have_correct_access_rules(
         self, wins_per_region: Tuple[int, ...], num_regions: int, region_template: str

--- a/apworld/brotato/test/test_starting_characters.py
+++ b/apworld/brotato/test/test_starting_characters.py
@@ -8,9 +8,6 @@ _character_items = item_name_groups["Characters"]
 
 
 class TestBrotatoStartingCharacters(BrotatoTestBase):
-    run_default_tests = False
-    auto_construct = False
-
     def _run(
         self,
         num_characters: int,


### PR DESCRIPTION
Added options to group crates together so they're only available after enough wins have been received. This is implemented as separate regions for each crate group. This prevents crates from being available from sphere 0.

Also also options to require multiple crates to be picked up to generate a check.

This is only the apworld changes for now. The client mod changes will require bigger refactors to support the options.

