### PR TITLE
Update options: fix formatting, naming, remove unused options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,11 +37,25 @@ objects for better organization and readability.
 - (Internal) AP client now handles `RoomUpdate` commands.
 - (Internal) Rename `BrotatoApSession` to `BrotatoApClient`.
 - (Internal) Rename `ApPlayerSession` to `GodotApClient`.
+- Options descriptions now use reStructuredText formatting to make them look nicer.
+- Updated names of all options to be shorter and have a more consistent style.
+- Reworded some option descriptions to reflect changes to the randomizer and make the
+  options clearer.
+- `(Legendary) Loot Crates per Check` has been renamed to `(Legendary) Crate Pickup
+  Step`.
+- `Number of normal crate drop locations` has been renamed to `Loot Crate Locations`.
+- `Number of legendary crate drop locations` has been renamed to `Legendary Loot Crate
+  Locations`.
+- Default value for `(Legendary) Crate Pickup Step` is now 1 instead of 0.
+  - 0 was a nonsensical value for this option.
 
 ### Fixed
 - XP and gold given to player is now properly tracked between connections to the
   multiworld.
 - Brotato items other than common items are now included in the Archipelago item pool.
+
+### Removed
+- Removed the unused option `Shop items`.
 
 ## [0.0.6] - 2024-03-27
 

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -49,7 +49,8 @@ class BrotatoWeb(WebWorld):
             ["RampagingHippy"],
         )
     ]
-    theme: str = "dirt"
+    theme = "dirt"
+    rich_text_options_doc = True
 
 
 class BrotatoWorld(World):

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -201,9 +201,6 @@ class BrotatoWorld(World):
         num_shop_slot_items = max(MAX_SHOP_SLOTS - num_starting_shop_slots, 0)
         item_names += [ItemName.SHOP_SLOT] * num_shop_slot_items
 
-        for _ in range(self.options.num_shop_items):
-            pass
-
         itempool = [self.create_item(item_name) for item_name in item_names]
 
         total_locations = (

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -26,7 +26,7 @@ class NumberRequiredWins(Range):
     range_start = 1
     range_end = NUM_CHARACTERS
 
-    display_name = "Number of runs required"
+    display_name = "Wins Required"
     default = 10
 
 
@@ -40,7 +40,7 @@ class StartingCharacters(TextChoice):
     option_default_characters = 0
     option_random_characters = 1
 
-    display_name = "Starting characters"
+    display_name = "Starting Characters"
     default = 0
 
 
@@ -50,7 +50,7 @@ class NumberStartingCharacters(Range):
     range_start = 1
     range_end = NUM_CHARACTERS
 
-    display_name = "Number of starting characters"
+    display_name = "Number of Starting Characters"
     default = 5
 
 
@@ -66,7 +66,7 @@ class WavesPerCheck(Range):
     range_start = 1
     range_end = NUM_WAVES
 
-    display_name = "Waves per check"
+    display_name = "Waves Per Check"
     default = 10
 
 
@@ -94,7 +94,7 @@ class NumberCommonCrateDropsPerCheck(Range):
     range_start = 0
     range_end: int = MAX_NORMAL_CRATE_DROPS
 
-    display_name: str = "Loot Crates per Check"
+    display_name: str = "Crate Pickup Step"
 
 
 class NumberCommonCrateDropGroups(Range):
@@ -127,7 +127,7 @@ class NumberLegendaryCrateDropLocations(Range):
     range_start = 0
     range_end: int = MAX_LEGENDARY_CRATE_DROPS
 
-    display_name: str = "Number of legendary crate drop locations"
+    display_name: str = "Number of Legendary Crate Drop Locations"
     default = 5
 
 
@@ -141,7 +141,7 @@ class NumberLegendaryCrateDropsPerCheck(Range):
     range_end: int = MAX_NORMAL_CRATE_DROPS
     default = 1
 
-    display_name: str = "Loot crates per check"
+    display_name: str = "Legendary Loot Crate Pickup Step"
 
 
 class NumberLegendaryCrateDropGroups(Range):
@@ -159,7 +159,7 @@ class NumberLegendaryCrateDropGroups(Range):
     range_start = 1
     range_end: int = MAX_LEGENDARY_CRATE_DROP_GROUPS
     default = 1
-    display_name: str = "Loot Crate Groups"
+    display_name: str = "Legendary Loot Crate Groups"
 
 
 class ItemWeights(Choice):
@@ -233,7 +233,7 @@ class NumberCommonUpgrades(Range):
     range_start = 0
     range_end: int = MAX_COMMON_UPGRADES
 
-    display_name: str = "Number of level 1 upgrades"
+    display_name: str = "Common Upgrades"
     default = 15
 
 
@@ -243,7 +243,7 @@ class NumberUncommonUpgrades(Range):
     range_start = 0
     range_end: int = MAX_UNCOMMON_UPGRADES
 
-    display_name: str = "Number of level 2 upgrades"
+    display_name: str = "Uncommon Upgrades"
     default = 10
 
 
@@ -253,7 +253,7 @@ class NumberRareUpgrades(Range):
     range_start = 0
     range_end: int = MAX_RARE_UPGRADES
 
-    display_name: str = "Number of level 3 upgrades"
+    display_name: str = "Rare Upgrades"
     default = 5
 
 
@@ -263,7 +263,7 @@ class NumberLegendaryUpgrades(Range):
     range_start = 0
     range_end = MAX_LEGENDARY_UPGRADES
 
-    display_name = "Number of level 4 upgrades"
+    display_name = "Legendary Upgrades"
     default = 5
 
 
@@ -272,7 +272,7 @@ class StartingShopSlots(Range):
 
     range_start = 0
     range_end: int = MAX_SHOP_SLOTS
-    display_name: str = "Starting shop slots"
+    display_name: str = "Starting Shop Slots"
     default = 4
 
 

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -20,8 +20,8 @@ from .constants import (
 class NumberRequiredWins(Range):
     """The number of runs you need to win to complete your goal.
 
-
-    Each win must be done with a different character."""
+    Each win must be done with a different character.
+    """
 
     range_start = 1
     range_end = NUM_CHARACTERS
@@ -71,9 +71,7 @@ class WavesPerCheck(Range):
 
 
 class NumberCommonCrateDropLocations(Range):
-    """The number of loot crate locations.
-
-    This replaces the loot crate drops in-game with an Archipelago item which must be picked up.
+    """Replaces the in-game loot crate drops with an Archipelago item which must be picked up to generate a check.
 
     How the drops are made available and how many are needed to make a check are controlled by the next two settings.
     """
@@ -82,7 +80,7 @@ class NumberCommonCrateDropLocations(Range):
     range_end = MAX_NORMAL_CRATE_DROPS
 
     default = 25
-    display_name = "Number of normal crate drop locations"
+    display_name = "Loot Crate Locations"
 
 
 class NumberCommonCrateDropsPerCheck(Range):
@@ -118,9 +116,8 @@ class NumberCommonCrateDropGroups(Range):
 
 
 class NumberLegendaryCrateDropLocations(Range):
-    """The number of legendary loot crate locations.
-
-    This replaces the legendary loot crate drops in-game with an Archipelago item which must be picked up.
+    """Replaces the in-game legendary loot crate drops with an Archipelago item which must be picked up to generate a
+    check.
 
     How the drops are made available and how many are needed to make a check are controlled by the next two settings.
     """
@@ -129,7 +126,7 @@ class NumberLegendaryCrateDropLocations(Range):
     range_end: int = MAX_LEGENDARY_CRATE_DROPS
 
     default = 5
-    display_name: str = "Number of Legendary Crate Drop Locations"
+    display_name: str = "Legendary Loot Crate Locations"
 
 
 class NumberLegendaryCrateDropsPerCheck(Range):

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -228,7 +228,7 @@ class LegendaryItemWeight(Range):
 
 
 class NumberCommonUpgrades(Range):
-    """The normal of level 1 upgrades to include in the item pool."""
+    """The number of Common/Tier 1/White upgrades to include in the item pool."""
 
     range_start = 0
     range_end: int = MAX_COMMON_UPGRADES
@@ -238,7 +238,7 @@ class NumberCommonUpgrades(Range):
 
 
 class NumberUncommonUpgrades(Range):
-    """The normal of level 2 upgrades to include in the item pool."""
+    """The number of Uncommon/Tier 2/Blue upgrades to include in the item pool."""
 
     range_start = 0
     range_end: int = MAX_UNCOMMON_UPGRADES
@@ -248,7 +248,7 @@ class NumberUncommonUpgrades(Range):
 
 
 class NumberRareUpgrades(Range):
-    """The normal of level 3 upgrades to include in the item pool."""
+    """The number of Rare/Tier 3/Purple upgrades to include in the item pool."""
 
     range_start = 0
     range_end: int = MAX_RARE_UPGRADES
@@ -258,7 +258,7 @@ class NumberRareUpgrades(Range):
 
 
 class NumberLegendaryUpgrades(Range):
-    """The normal of level 4 upgrades to include in the item pool."""
+    """The number of Legendary/Tier 4/Red upgrades to include in the item pool."""
 
     range_start = 0
     range_end = MAX_LEGENDARY_UPGRADES

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -32,9 +32,8 @@ class NumberRequiredWins(Range):
 class StartingCharacters(TextChoice):
     """Determines your set of starting characters.
 
-    Default: Start with Well Rounded, Brawler, Crazy, Ranger and Mage.
-
-    Shuffle: Start with a random selection of characters.
+    * Default: Start with Well Rounded, Brawler, Crazy, Ranger and Mage.
+    * Shuffle: Start with a random selection of characters.
     """
 
     option_default_characters = 0
@@ -55,7 +54,10 @@ class NumberStartingCharacters(Range):
 
 
 class WavesPerCheck(Range):
-    """How many waves to win to receive a check. Smaller values mean more frequent checks."""
+    """How many waves to win to receive a check.
+
+    1 means every wave is a check, 2 means every other wave, etc.
+    """
 
     # We'd make the start 1, but the number of items sent when the game is released is
     # so large that the resulting ReceivedItems command is bigger than Godot 3.5's
@@ -83,11 +85,9 @@ class NumberCommonCrateDropLocations(Range):
 
 
 class NumberCommonCrateDropsPerCheck(Range):
-    """The number of loot crates needed to check a location.
+    """The number of common loot crates which need to be picked up to count as a check.
 
-    1 means every loot crate pickup gives a check,
-    2 means every other loot crate,
-    etc.
+    1 means every crate is a check, 2 means every other crate, etc.
     """
 
     range_start = 0
@@ -99,9 +99,11 @@ class NumberCommonCrateDropsPerCheck(Range):
 class NumberCommonCrateDropGroups(Range):
     """The number of groups to separate loot crate locations into.
 
-    Once you check all the locations in a group, the randomizer will not drop more loot crate Archipelago items until you win more runs.
+    Once you check all the locations in a group, the randomizer will not drop more loot crate Archipelago items until
+    you win more runs.
 
-    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out over the number of wins you choose.
+    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out
+    over the number of wins you choose.
 
     Set to 1 to make all loot crate locations available from the start.
     """
@@ -129,9 +131,9 @@ class NumberLegendaryCrateDropLocations(Range):
 
 
 class NumberLegendaryCrateDropsPerCheck(Range):
-    """The number of legendary loot crates needed to check a location.
+    """The number of legendary loot crates which need to be picked up to count as a check.
 
-    1 means every loot crate pickup gives a check, 2 means every other loot crate, etc.
+    1 means every crate is a check, 2 means every other crate, etc.
     """
 
     range_start = 0
@@ -144,9 +146,11 @@ class NumberLegendaryCrateDropsPerCheck(Range):
 class NumberLegendaryCrateDropGroups(Range):
     """The number of groups to separate legendary loot crate locations into.
 
-    Once you check all the locations in a group, the randomizer will not drop more legendary loot crate Archipelago items until you win more runs.
+    Once you check all the locations in a group, the randomizer will not drop more legendary loot crate Archipelago
+    items until you win more runs.
 
-    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out over the number of wins you choose.
+    The number of loot crate locations will be evenly split among the groups, and the groups will be evenly spread out
+    over the number of wins you choose.
 
     Set to 1 to make all legendary loot crate locations available from the start.
     """
@@ -163,11 +167,12 @@ class ItemWeights(Choice):
     For every common crate drop location, a Brotato weapon/item will be added to the pool. This controls how the item
     tiers are chosen.
 
-    Note that legendary crate drop locations will ALWAYS add a legendary item to the pool, which is in addition to any legendary items added by common crate locations.
+    Note that legendary crate drop locations will ALWAYS add a legendary item to the pool, which is in addition to any
+    legendary items added by common crate locations.
 
-    - Default: Use the game's normal distribution. Equivalent to setting the custom weights to 100/60/25/8.
-    - Chaos: Each tier has a has a random weight.
-    - Custom: Use the custom weight options below.
+    * Default: Use the game's normal distribution. Equivalent to setting the custom weights to 100/60/25/8.
+    * Chaos: Each tier has a has a random weight.
+    * Custom: Use the custom weight options below.
     """
 
     option_default = 0
@@ -210,7 +215,8 @@ class RareItemWeight(Range):
 class LegendaryItemWeight(Range):
     """The weight of Legendary/Tier 4/Red items in the pool.
 
-    Note that this is for common crate drop locations only. An additional number of legendary items is also added for each legendary crate drop location.
+    Note that this is for common crate drop locations only. An additional number of legendary items is also added for
+    each legendary crate drop location.
     """
 
     range_start = 0

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -26,8 +26,8 @@ class NumberRequiredWins(Range):
     range_start = 1
     range_end = NUM_CHARACTERS
 
-    display_name = "Wins Required"
     default = 10
+    display_name = "Wins Required"
 
 
 class StartingCharacters(TextChoice):
@@ -40,8 +40,8 @@ class StartingCharacters(TextChoice):
     option_default_characters = 0
     option_random_characters = 1
 
-    display_name = "Starting Characters"
     default = 0
+    display_name = "Starting Characters"
 
 
 class NumberStartingCharacters(Range):
@@ -50,8 +50,8 @@ class NumberStartingCharacters(Range):
     range_start = 1
     range_end = NUM_CHARACTERS
 
-    display_name = "Number of Starting Characters"
     default = 5
+    display_name = "Number of Starting Characters"
 
 
 class WavesPerCheck(Range):
@@ -66,8 +66,8 @@ class WavesPerCheck(Range):
     range_start = 1
     range_end = NUM_WAVES
 
-    display_name = "Waves Per Check"
     default = 10
+    display_name = "Waves Per Check"
 
 
 class NumberCommonCrateDropLocations(Range):
@@ -81,8 +81,8 @@ class NumberCommonCrateDropLocations(Range):
     range_start = 0
     range_end = MAX_NORMAL_CRATE_DROPS
 
-    display_name = "Number of normal crate drop locations"
     default = 25
+    display_name = "Number of normal crate drop locations"
 
 
 class NumberCommonCrateDropsPerCheck(Range):
@@ -91,9 +91,10 @@ class NumberCommonCrateDropsPerCheck(Range):
     1 means every crate is a check, 2 means every other crate, etc.
     """
 
-    range_start = 0
+    range_start = 1
     range_end: int = MAX_NORMAL_CRATE_DROPS
 
+    default = 2
     display_name: str = "Crate Pickup Step"
 
 
@@ -112,8 +113,8 @@ class NumberCommonCrateDropGroups(Range):
     range_start = 1
     range_end: int = MAX_NORMAL_CRATE_DROP_GROUPS
 
-    display_name: str = "Loot Crate Groups"
     default = 1
+    display_name: str = "Loot Crate Groups"
 
 
 class NumberLegendaryCrateDropLocations(Range):
@@ -127,8 +128,8 @@ class NumberLegendaryCrateDropLocations(Range):
     range_start = 0
     range_end: int = MAX_LEGENDARY_CRATE_DROPS
 
-    display_name: str = "Number of Legendary Crate Drop Locations"
     default = 5
+    display_name: str = "Number of Legendary Crate Drop Locations"
 
 
 class NumberLegendaryCrateDropsPerCheck(Range):
@@ -137,10 +138,10 @@ class NumberLegendaryCrateDropsPerCheck(Range):
     1 means every crate is a check, 2 means every other crate, etc.
     """
 
-    range_start = 0
+    range_start = 1
     range_end: int = MAX_NORMAL_CRATE_DROPS
-    default = 1
 
+    default = 1
     display_name: str = "Legendary Loot Crate Pickup Step"
 
 
@@ -158,6 +159,7 @@ class NumberLegendaryCrateDropGroups(Range):
 
     range_start = 1
     range_end: int = MAX_LEGENDARY_CRATE_DROP_GROUPS
+
     default = 1
     display_name: str = "Legendary Loot Crate Groups"
 
@@ -189,8 +191,8 @@ class CommonItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    display_name = "Common Items"
     default = 100
+    display_name = "Common Items"
 
 
 class UncommonItemWeight(Range):
@@ -199,8 +201,8 @@ class UncommonItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    display_name = "Uncommon Items"
     default = 60
+    display_name = "Uncommon Items"
 
 
 class RareItemWeight(Range):
@@ -209,8 +211,8 @@ class RareItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    display_name = "Rare Items"
     default = 25
+    display_name = "Rare Items"
 
 
 class LegendaryItemWeight(Range):
@@ -223,8 +225,8 @@ class LegendaryItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    display_name = "Legendary Items"
     default = 8
+    display_name = "Legendary Items"
 
 
 class NumberCommonUpgrades(Range):
@@ -233,8 +235,8 @@ class NumberCommonUpgrades(Range):
     range_start = 0
     range_end: int = MAX_COMMON_UPGRADES
 
-    display_name: str = "Common Upgrades"
     default = 15
+    display_name: str = "Common Upgrades"
 
 
 class NumberUncommonUpgrades(Range):
@@ -243,8 +245,8 @@ class NumberUncommonUpgrades(Range):
     range_start = 0
     range_end: int = MAX_UNCOMMON_UPGRADES
 
-    display_name: str = "Uncommon Upgrades"
     default = 10
+    display_name: str = "Uncommon Upgrades"
 
 
 class NumberRareUpgrades(Range):
@@ -253,8 +255,8 @@ class NumberRareUpgrades(Range):
     range_start = 0
     range_end: int = MAX_RARE_UPGRADES
 
-    display_name: str = "Rare Upgrades"
     default = 5
+    display_name: str = "Rare Upgrades"
 
 
 class NumberLegendaryUpgrades(Range):
@@ -263,8 +265,8 @@ class NumberLegendaryUpgrades(Range):
     range_start = 0
     range_end = MAX_LEGENDARY_UPGRADES
 
-    display_name = "Legendary Upgrades"
     default = 5
+    display_name = "Legendary Upgrades"
 
 
 class StartingShopSlots(Range):
@@ -272,8 +274,9 @@ class StartingShopSlots(Range):
 
     range_start = 0
     range_end: int = MAX_SHOP_SLOTS
-    display_name: str = "Starting Shop Slots"
+
     default = 4
+    display_name: str = "Starting Shop Slots"
 
 
 @dataclass

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -275,15 +275,6 @@ class StartingShopSlots(Range):
     default = 4
 
 
-class NumberShopItems(Range):
-    """The number of items to place in the shop"""
-
-    range_start = 0
-    range_end: int = MAX_SHOP_LOCATIONS_PER_TIER[ItemRarity.COMMON]
-    display_name: str = "Shop items"
-    default = 10
-
-
 @dataclass
 class BrotatoOptions(PerGameCommonOptions):
     num_victories: NumberRequiredWins
@@ -306,4 +297,3 @@ class BrotatoOptions(PerGameCommonOptions):
     num_rare_upgrades: NumberRareUpgrades
     num_legendary_upgrades: NumberLegendaryUpgrades
     num_starting_shop_slots: StartingShopSlots
-    num_shop_items: NumberShopItems

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -10,17 +10,18 @@ from .constants import (
     MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
     MAX_RARE_UPGRADES,
-    MAX_SHOP_LOCATIONS_PER_TIER,
     MAX_SHOP_SLOTS,
     MAX_UNCOMMON_UPGRADES,
     NUM_CHARACTERS,
     NUM_WAVES,
-    ItemRarity,
 )
 
 
 class NumberRequiredWins(Range):
-    """The number of characters you must complete runs with to win."""
+    """The number of runs you need to win to complete your goal.
+
+
+    Each win must be done with a different character."""
 
     range_start = 1
     range_end = NUM_CHARACTERS


### PR DESCRIPTION
- Remove unused option `shop_slots`.
- Update option descriptions to use rST now that Archipelago supports it. This means cleaner tooltips and no weird formatting in the docstrings.
- Update option names and descriptions to have a more consistent format and casing. See the changelog for details.
- **No functionality has been changed in this PR.**