### PR TITLE
Make AP menus controller-friendly, and password text secret

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,11 +55,15 @@ objects for better organization and readability.
   Locations`.
 - Default value for `(Legendary) Crate Pickup Step` is now 1 instead of 0.
   - 0 was a nonsensical value for this option.
+- Archipelago password text is now hidden by default, with a button to toggle.
 
 ### Fixed
 - XP and gold given to player is now properly tracked between connections to the
   multiworld.
 - Brotato items other than common items are now included in the Archipelago item pool.
+- Archipelago connect button on the main menu can now be navigated to with controller
+  and keyboard.
+- Archipelago connect menu can now be navigated with controller and keyboard.
 
 ### Removed
 - Removed the unused option `Shop items`.

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
@@ -9,6 +9,10 @@ signal ap_connect_button_pressed
 
 func init():
 	.init()
+	if _archipelago_button != null:
+		# Godot inheritance/call-order rules means we have to set the neighbor here for
+		# it take.
+		quit_button.focus_neighbour_bottom = _archipelago_button.get_path()
 
 func _ready():
 	._ready()
@@ -18,18 +22,28 @@ func _ready():
 	_set_ap_button_icon(_ap_websocket_connection.connection_state)
 
 func _add_ap_button():
-	var parent_node_name = "HBoxContainer/ButtonsLeft"
-	var parent_node: BoxContainer = get_node(parent_node_name)
+	var parent_node: Container = $HBoxContainer/ButtonsLeft
 
 	ModLoaderMod.append_node_in_scene(
 		self,
 		"ArchipelagoButton",
-		parent_node_name,
+		parent_node.get_path(),
 		"res://mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/archipelago_connect_button.tscn"
 	)
-	_archipelago_button = get_node(parent_node_name +"/ArchipelagoButton")
+	_archipelago_button = parent_node.get_node("ArchipelagoButton")
 	parent_node.move_child(_archipelago_button, 0)
 	_archipelago_button.connect("pressed", self, "_on_MainMenu_ap_connect_button_pressed")
+
+	# Make AP button reachable with controller. We setup Quit -> AP in _init()
+	var bottom_neighbor
+	if ProgressData.current_run_state.has_run_state:
+		bottom_neighbor = continue_button
+	else:
+		bottom_neighbor = start_button
+
+	_archipelago_button.focus_neighbour_top = quit_button.get_path()
+	_archipelago_button.focus_neighbour_bottom = bottom_neighbor.get_path()
+	bottom_neighbor.focus_neighbour_top = _archipelago_button.get_path()
 
 func _set_ap_button_icon(ws_state: int):
 	var icon: Texture

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
@@ -24,8 +24,7 @@ const _STATUS_TEXTURE_ROTATION_SPEED_DEGREES_PER_SECOND = 360
 var _animate_status_texture: bool = false
 
 func init():
-	# Needed to make the scene switch in title_screen_menus happy.
-	pass
+	_host_edit.grab_focus()
 
 func _ready():
 	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
@@ -14,7 +14,8 @@ onready var _connect_status_label: Label = $"VBoxContainer/ConnectStatusLabel"
 onready var _connect_error_label: Label = $"VBoxContainer/ConnectionErrorLabel"
 onready var _host_edit: LineEdit = $"VBoxContainer/CenterContainer/GridContainer/HostEdit"
 onready var _player_edit: LineEdit = $"VBoxContainer/CenterContainer/GridContainer/PlayerEdit"
-onready var _password_edit: LineEdit = $"VBoxContainer/CenterContainer/GridContainer/PasswordEdit"
+onready var _password_edit: LineEdit = $"VBoxContainer/CenterContainer/GridContainer/HBoxContainer/PasswordEdit"
+onready var _show_password_button = $"VBoxContainer/CenterContainer/GridContainer/HBoxContainer/ShowPasswordButton"
 onready var _status_texture: TextureRect = $"VBoxContainer/StatusTexture"
 
 onready var _ap_client
@@ -153,3 +154,13 @@ func _process(delta):
 			# Rotation goes from -360 to 360 degrees
 			new_angle -= _MAX_ANGLE_DEGREES * 2
 		_status_texture.rect_rotation = new_angle
+
+
+func _on_ShowPasswordButton_pressed():
+	# Toggle if password edit text is secret
+	if _password_edit.secret:
+		_password_edit.secret = false
+		_show_password_button.text = "Hide"
+	else:
+		_password_edit.secret = true
+		_show_password_button.text = "Show"

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
@@ -42,6 +42,7 @@ margin_left = 238.0
 margin_right = 738.0
 margin_bottom = 54.0
 rect_min_size = Vector2( 500, 0 )
+focus_neighbour_top = NodePath("../../../BackButton")
 focus_next = NodePath("../PlayerEdit")
 focus_previous = NodePath("../../../BackButton")
 text = "archipelago.gg"
@@ -91,7 +92,7 @@ unique_name_in_owner = true
 margin_top = 411.0
 margin_right = 768.0
 margin_bottom = 476.0
-focus_next = NodePath("../BackButton")
+focus_next = NodePath("../DisconnectButton")
 focus_previous = NodePath("../CenterContainer/GridContainer/PasswordEdit")
 text = "Connect"
 
@@ -99,16 +100,16 @@ text = "Connect"
 margin_top = 526.0
 margin_right = 768.0
 margin_bottom = 591.0
-focus_next = NodePath("../CenterContainer/GridContainer/HostEdit")
-focus_previous = NodePath("../CenterContainer/GridContainer/PasswordEdit")
+focus_next = NodePath("../BackButton")
+focus_previous = NodePath("../ConnectButton")
 text = "Disconnect"
 
 [node name="BackButton" type="Button" parent="VBoxContainer"]
 margin_top = 641.0
 margin_right = 768.0
 margin_bottom = 706.0
-focus_next = NodePath("../CenterContainer/GridContainer/HostEdit")
-focus_previous = NodePath("../ConnectButton")
+focus_neighbour_bottom = NodePath("../CenterContainer/GridContainer/HostEdit")
+focus_previous = NodePath("../DisconnectButton")
 text = "MENU_BACK"
 script = ExtResource( 3 )
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
@@ -19,14 +19,14 @@ custom_constants/separation = 50
 alignment = 1
 
 [node name="CenterContainer" type="CenterContainer" parent="VBoxContainer"]
-margin_top = 149.0
+margin_top = 143.0
 margin_right = 768.0
-margin_bottom = 361.0
+margin_bottom = 366.0
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/CenterContainer"]
 margin_left = 15.0
 margin_right = 753.0
-margin_bottom = 212.0
+margin_bottom = 223.0
 custom_constants/vseparation = 25
 custom_constants/hseparation = 25
 columns = 2
@@ -62,7 +62,7 @@ margin_left = 238.0
 margin_top = 79.0
 margin_right = 738.0
 margin_bottom = 133.0
-focus_next = NodePath("../PasswordEdit")
+focus_next = NodePath("../HBoxContainer/PasswordEdit")
 focus_previous = NodePath("../HostEdit")
 clear_button_enabled = true
 placeholder_text = "Player Name"
@@ -70,54 +70,65 @@ caret_blink = true
 caret_blink_speed = 0.5
 
 [node name="PasswordLabel" type="Label" parent="VBoxContainer/CenterContainer/GridContainer"]
-margin_top = 162.0
+margin_top = 168.0
 margin_right = 213.0
-margin_bottom = 207.0
+margin_bottom = 213.0
 text = "Password:"
 
-[node name="PasswordEdit" type="LineEdit" parent="VBoxContainer/CenterContainer/GridContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/CenterContainer/GridContainer"]
 margin_left = 238.0
 margin_top = 158.0
 margin_right = 738.0
-margin_bottom = 212.0
-focus_next = NodePath("../../../ConnectButton")
-focus_previous = NodePath("../PlayerEdit")
+margin_bottom = 223.0
+
+[node name="PasswordEdit" type="LineEdit" parent="VBoxContainer/CenterContainer/GridContainer/HBoxContainer"]
+margin_right = 340.0
+margin_bottom = 65.0
+focus_next = NodePath("../../../../ConnectButton")
+focus_previous = NodePath("../../PlayerEdit")
+size_flags_horizontal = 3
 secret = true
 clear_button_enabled = true
 placeholder_text = "Leave empty if no password"
 caret_blink = true
 caret_blink_speed = 0.5
 
+[node name="ShowPasswordButton" type="Button" parent="VBoxContainer/CenterContainer/GridContainer/HBoxContainer"]
+margin_left = 362.0
+margin_right = 500.0
+margin_bottom = 65.0
+text = "Show"
+
 [node name="ConnectButton" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
-margin_top = 411.0
+margin_top = 416.0
 margin_right = 768.0
-margin_bottom = 476.0
+margin_bottom = 481.0
 focus_next = NodePath("../DisconnectButton")
-focus_previous = NodePath("../CenterContainer/GridContainer/PasswordEdit")
+focus_previous = NodePath("../CenterContainer/GridContainer/HBoxContainer/PasswordEdit")
 text = "Connect"
 
 [node name="DisconnectButton" type="Button" parent="VBoxContainer"]
-margin_top = 526.0
+margin_top = 531.0
 margin_right = 768.0
-margin_bottom = 591.0
+margin_bottom = 596.0
 focus_next = NodePath("../BackButton")
 focus_previous = NodePath("../ConnectButton")
 text = "Disconnect"
 
 [node name="BackButton" type="Button" parent="VBoxContainer"]
-margin_top = 641.0
+margin_top = 646.0
 margin_right = 768.0
-margin_bottom = 706.0
+margin_bottom = 711.0
 focus_neighbour_bottom = NodePath("../CenterContainer/GridContainer/HostEdit")
 focus_previous = NodePath("../DisconnectButton")
 text = "MENU_BACK"
 script = ExtResource( 3 )
 
 [node name="ConnectStatusLabel" type="Label" parent="VBoxContainer"]
-margin_top = 756.0
+margin_top = 761.0
 margin_right = 768.0
-margin_bottom = 801.0
+margin_bottom = 806.0
 text = "Connection Status"
 align = 1
 
@@ -131,13 +142,14 @@ text = "Connection Error"
 align = 1
 
 [node name="StatusTexture" type="TextureRect" parent="VBoxContainer"]
-margin_top = 851.0
+margin_top = 856.0
 margin_right = 768.0
-margin_bottom = 931.0
+margin_bottom = 936.0
 rect_pivot_offset = Vector2( 384, 40 )
 texture = ExtResource( 4 )
 stretch_mode = 4
 
+[connection signal="pressed" from="VBoxContainer/CenterContainer/GridContainer/HBoxContainer/ShowPasswordButton" to="." method="_on_ShowPasswordButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/ConnectButton" to="." method="_on_ConnectButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/DisconnectButton" to="." method="_on_DisconnectButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_BackButton_pressed"]

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
@@ -82,6 +82,7 @@ margin_right = 738.0
 margin_bottom = 212.0
 focus_next = NodePath("../../../ConnectButton")
 focus_previous = NodePath("../PlayerEdit")
+secret = true
 clear_button_enabled = true
 placeholder_text = "Leave empty if no password"
 caret_blink = true

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.tscn
@@ -84,6 +84,7 @@ margin_bottom = 223.0
 [node name="PasswordEdit" type="LineEdit" parent="VBoxContainer/CenterContainer/GridContainer/HBoxContainer"]
 margin_right = 340.0
 margin_bottom = 65.0
+focus_neighbour_right = NodePath("../ShowPasswordButton")
 focus_next = NodePath("../../../../ConnectButton")
 focus_previous = NodePath("../../PlayerEdit")
 size_flags_horizontal = 3
@@ -97,6 +98,8 @@ caret_blink_speed = 0.5
 margin_left = 362.0
 margin_right = 500.0
 margin_bottom = 65.0
+focus_neighbour_left = NodePath("../PasswordEdit")
+focus_neighbour_bottom = NodePath("../../../../ConnectButton")
 text = "Show"
 
 [node name="ConnectButton" type="Button" parent="VBoxContainer"]


### PR DESCRIPTION
Properly setup neighbor focus for the AP Connect button in the main menu so it can be reached with controller or keyboard input.

On the AP connect menu:
* Make the host edit focused by default so we can navigate the UI by controller
* Fix neighbor focus so we can cycle through the controls from top->bottom and bottom->top
* Make password edit text secret
* Add button next to password edit to toggle if it's secret or not.