### PR TITLE
Add option to only include certain characters in the multiworld 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New option: "Include Characters", to include/exclude certain characters from the world
+  if players don't want to play as them.
+  - Characters not included in the option will not have an item to unlock them, and
+    their run and wave complete checks will be excluded from the world.
+  - Currently, the option is defined in the YAML only, NOT on the options page. This is
+    an Archipelago core limitation.
+
+### Changed
+- World generation will now remove Brotato items and upgrades from the Archipelago item
+  pool if there are not enough locations.
+  - This typically occurs if too few characters are included with the new "Include
+    Characters" option.
+
 ## [0.1.0] - 2024-07-07
 
 ### Added

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -74,14 +74,17 @@ class BrotatoWorld(World):
     _filler_items: List[str] = filler_items
     _starting_characters: List[str]
     _include_characters: Set[str]
-    _exclude_characters: Set[str]
-    """The characters to actually create items/checks for. Derived from options.include_characters.
+    """The characters whose locations (wave/run complete) may have progression and useful items.
+
+    This is derived from options.include_characters.
 
     This is a distinct list from the options value because:
 
     * We want to sanitize the list to make sure typos or other errors don't cause bugs down the road.
     * We want to keep things in character definition order for readability by using a list instead of a set.
     """
+    _exclude_characters: Set[str]
+    """All characters not inlcuded in options.include_characters. Their locations will be marked as EXCLUDED."""
 
     location_name_to_id: ClassVar[Dict[str, int]] = location_name_to_id
     location_name_groups: ClassVar[Dict[str, Set[str]]] = location_name_groups

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -273,13 +273,12 @@ class BrotatoWorld(World):
         ]
         character_region.locations.append(character_run_won_location.to_location(self.player, parent=character_region))
 
-        character_wave_drop_location_names: List[str] = [
-            WAVE_COMPLETE_LOCATION_TEMPLATE.format(wave=w, char=character) for w in self.waves_with_checks
-        ]
-        character_region.locations.extend(
-            location_table[loc].to_location(self.player, parent=character_region)
-            for loc in character_wave_drop_location_names
-        )
+        for wave in self.waves_with_checks:
+            wave_complete_location_name = WAVE_COMPLETE_LOCATION_TEMPLATE.format(wave=wave, char=character)
+            wave_complete_location = location_table[wave_complete_location_name].to_location(
+                self.player, parent=character_region
+            )
+            character_region.locations.append(wave_complete_location)
 
         has_character_rule = create_has_character_rule(self.player, character)
         parent_region.connect(

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -181,12 +181,6 @@ class BrotatoWorld(World):
 
             character_regions.append(character_region)
 
-            # # Crates can be gotten with any character...
-            # character_region.connect(crate_drop_region, f"Drop crates for {character}")
-            # # ...but we need to make sure you don't go to another character's in-game before you have them.
-            # crate_drop_region.connect(character_region, f"Exit drop crates for {character}", rule=has_character_rule)
-            # character_regions.append(character_region)
-
         self.multiworld.regions.extend(
             [
                 menu_region,

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -105,3 +105,4 @@ SHOP_ITEM_LOCATION_TEMPLATE = "{tier} Shop Item {num}"
 # Region name string templates
 CRATE_DROP_GROUP_REGION_TEMPLATE = "Loot Crate Group {num}"
 LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE = "Legendary Loot Crate Group {num}"
+CHARACTER_REGION_TEMPLATE = "In-Game ({char})"

--- a/apworld/brotato/locations.py
+++ b/apworld/brotato/locations.py
@@ -84,5 +84,4 @@ location_name_groups: Dict[str, Set[str]] = {
     "Run Win Specific Character": set(c.name for c in _character_run_won_locations),
     "Normal Crate Drops": set(c.name for c in _loot_crate_drop_locations),
     "Legendary Crate Drops": set(c.name for c in _legendary_loot_crate_drop_locations),
-    # "Shop Items": set(c.name for c in _shop_item_locations),
 }

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -58,12 +58,11 @@ class NumberStartingCharacters(Range):
 class IncludeCharacters(OptionSet):
     """Which characters to include for checks.
 
-    Characters not listed here will NOT be included in any locations or items. This
-    includes:
+    Characters not listed here will still be available and unlockable, but they will not have any progression or useful
+    items in their locations. This includes:
 
     * Won runs for goal completion.
     * Wave complete checks.
-    * Character items will not be included (so the character will always be locked).
     """
 
     default = frozenset(CHARACTERS)

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -58,11 +58,8 @@ class NumberStartingCharacters(Range):
 class IncludeCharacters(OptionSet):
     """Which characters to include for checks.
 
-    Characters not listed here will still be available and unlockable, but they will not have any progression or useful
-    items in their locations. This includes:
-
-    * Won runs for goal completion.
-    * Wave complete checks.
+    Characters not listed here will not be available to play. There will be no item to unlock them, and there will be
+    no run or wave complete checks associated with them.
     """
 
     default = frozenset(CHARACTERS)

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
-from Options import Choice, PerGameCommonOptions, Range, TextChoice
+from Options import Choice, OptionSet, PerGameCommonOptions, Range, TextChoice
 
 from .constants import (
+    CHARACTERS,
     MAX_COMMON_UPGRADES,
     MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
@@ -33,7 +34,7 @@ class NumberRequiredWins(Range):
 class StartingCharacters(TextChoice):
     """Determines your set of starting characters.
 
-    * Default: Start with Well Rounded, Brawler, Crazy, Ranger and Mage.
+    * Default: Start with Well Rounded, Brawler, Crazy, Ranger and Mage (unless they aren't in "Include Characters").
     * Shuffle: Start with a random selection of characters.
     """
 
@@ -52,6 +53,21 @@ class NumberStartingCharacters(Range):
 
     default = 5
     display_name = "Number of Starting Characters"
+
+
+class IncludeCharacters(OptionSet):
+    """Which characters to include for checks.
+
+    Characters not listed here will NOT be included in any locations or items. This
+    includes:
+
+    * Won runs for goal completion.
+    * Wave complete checks.
+    * Character items will not be included (so the character will always be locked).
+    """
+
+    default = frozenset(CHARACTERS)
+    display_name = "Include Characters"
 
 
 class WavesPerCheck(Range):
@@ -280,6 +296,7 @@ class StartingShopSlots(Range):
 class BrotatoOptions(PerGameCommonOptions):
     num_victories: NumberRequiredWins
     starting_characters: StartingCharacters
+    include_characters: IncludeCharacters
     num_starting_characters: NumberStartingCharacters
     waves_per_drop: WavesPerCheck
     num_common_crate_drops: NumberCommonCrateDropLocations

--- a/apworld/brotato/test/test_include_characters.py
+++ b/apworld/brotato/test/test_include_characters.py
@@ -1,0 +1,50 @@
+from ..constants import CHARACTER_REGION_TEMPLATE, CHARACTERS, DEFAULT_CHARACTERS
+from ..items import ItemName
+from . import BrotatoTestBase
+
+
+class TestBrotatoIncludeCharacters(BrotatoTestBase):
+    auto_construct = False
+
+    def test_include_characters_ignores_invalid_values(self):
+        valid_include_characters = CHARACTERS[:10]
+        invalid_include_characters = ["Jigglypuff", "asdfdadfdasdf", "", "ireallywishihadhypothesisrn"]
+        include_characters = {*valid_include_characters, *invalid_include_characters}
+        self.options = {
+            "starting_characters": 1,
+            "include_characters": include_characters,
+        }
+        self.world_setup()
+
+        expected_regions = {CHARACTER_REGION_TEMPLATE.format(char=char) for char in valid_include_characters}
+
+        character_regions = {
+            r.name for r in self.multiworld.regions if r.player == self.player and r.name.startswith("In-Game")
+        }
+
+        self.assertSetEqual(expected_regions, character_regions)
+
+    def test_include_characters_excludes_default_characters(self):
+        include_characters = set(CHARACTERS)
+        include_characters.remove("Brawler")
+        expected_starting_characters = set(DEFAULT_CHARACTERS)
+        expected_starting_characters.remove("Brawler")
+
+        self.options = {"starting_characters": 0, "include_characters": include_characters}
+        self.world_setup()
+
+        player_precollected = self.multiworld.precollected_items[self.player]
+        precollected_characters = {p.name for p in player_precollected if p.name in CHARACTERS}
+
+        self.assertSetEqual(precollected_characters, expected_starting_characters)
+
+    def test_include_characters_less_characters_than_wins_changes_goal(self):
+        include_characters = set(DEFAULT_CHARACTERS)
+        self.options = {"starting_characters": 1, "include_characters": include_characters, "wins_required": 30}
+        self.world_setup()
+
+        self.assertBeatable(False)
+        # Create a "Run Won" item for each character included, give them to the player, then check that we've "won"
+        run_won_items = [self.world.create_item(ItemName.RUN_COMPLETE) for _ in include_characters]
+        self.collect(run_won_items)
+        self.assertBeatable(True)

--- a/apworld/brotato/test/test_starting_characters.py
+++ b/apworld/brotato/test/test_starting_characters.py
@@ -22,8 +22,7 @@ class TestBrotatoStartingCharacters(BrotatoTestBase):
         self.world_setup()
 
         # Get precollected items
-        player_id = self.multiworld.player_ids[0]
-        player_precollected = self.multiworld.precollected_items[player_id]
+        player_precollected = self.multiworld.precollected_items[self.player]
         precollected_characters = [p for p in player_precollected if p.name in _character_items]
 
         # Check that the number of starting characters is correct
@@ -36,7 +35,7 @@ class TestBrotatoStartingCharacters(BrotatoTestBase):
                 len(expected_characters) == num_characters
             ), "Test configuration error, num_characters does not match len(expected_characters)."
             for ec in expected_characters:
-                expected_item = self.multiworld.worlds[player_id].create_item(ec)
+                expected_item = self.world.create_item(ec)
                 assert expected_item in precollected_characters
 
     def test_default_starting_characters(self):
@@ -47,14 +46,10 @@ class TestBrotatoStartingCharacters(BrotatoTestBase):
         )
 
     # TODO: Probably can't use pytest.paramterize, is there a better way?
-    def test_custom_starting_characters_1(self):
-        self._run_and_check(num_characters=1)
+    def test_custom_starting_characters(self):
+        for num_characters in range(1, len(CHARACTERS)):
+            with self.subTest(msg=f"{num_characters} starting characters"):
+                self._run_and_check(num_characters=num_characters)
 
-    def test_custom_starting_characters_5(self):
-        self._run_and_check(num_characters=5)
-
-    def test_custom_starting_characters_15(self):
-        self._run_and_check(num_characters=5)
-
-    def test_custom_starting_characters_max(self):
-        self._run_and_check(num_characters=len(CHARACTERS), expected_characters=CHARACTERS)
+        with self.subTest(msg=f"{len(CHARACTERS)} starting characters"):
+            self._run_and_check(num_characters=len(CHARACTERS), expected_characters=CHARACTERS)


### PR DESCRIPTION
In effect, this is an "exclude characters" option, but it's easier to maintain a whitelist than a blacklist, since it's less ambiguous and less prone to typos.

This change also had the side effect that we need to check if we have too many items for the number of available locations, since the number of checks scales with the number of included characters. If so, we remove loot crate and upgrade items from the pool until the number of items and locations match. If we can't even fit the necessary items (character unlocks), we just raise an `OptionError`.

The logic for above moved from `create_items` to `generate_early` since that seemed like a more fitting spot.