### PR TITLE
Mark legendary crate drop locations excluded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pool if there are not enough locations.
   - This typically occurs if too few characters are included with the new "Include
     Characters" option.
+- Legendary loot crate drops are now marked as `EXCLUDED`, to account for how
+ infrequently they drop.  
+ - This may be reverted in a future update.
 
 ## [0.1.0] - 2024-07-07
 

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -3,10 +3,9 @@ from collections import Counter
 from dataclasses import asdict
 from typing import Any, ClassVar, Dict, List, Literal, Set, Tuple, Union
 
-from BaseClasses import Item, MultiWorld, Region, Tutorial
+from BaseClasses import Item, LocationProgressType, MultiWorld, Region, Tutorial
 from Options import OptionError
 from worlds.AutoWorld import WebWorld, World
-from worlds.generic.Rules import add_item_rule
 
 from ._loot_crate_groups import BrotatoLootCrateGroup, build_loot_crate_groups
 from .constants import (
@@ -34,7 +33,7 @@ from .options import (
     RareItemWeight,
     UncommonItemWeight,
 )
-from .rules import create_has_character_rule, create_has_run_wins_rule, legendary_loot_crate_item_rule
+from .rules import create_has_character_rule, create_has_run_wins_rule
 
 logger = logging.getLogger("Brotato")
 
@@ -185,11 +184,7 @@ class BrotatoWorld(World):
         num_shop_slot_items = max(MAX_SHOP_SLOTS - self.options.num_starting_shop_slots.value, 0)
 
         # The number of locations available, not including the "Run Won" locations, which always have "Run Won" items.
-        num_locations = (
-            num_wave_complete_locations
-            + self.options.num_common_crate_drops.value
-            + self.options.num_legendary_crate_drops.value
-        )
+        num_locations = num_wave_complete_locations + self.options.num_common_crate_drops.value
         num_claimed_locations = (
             len(self._include_characters)  # For each character unlock
             + num_shop_slot_items
@@ -211,7 +206,7 @@ class BrotatoWorld(World):
             )
             for item_to_remove in items_to_remove:
                 self._upgrade_and_item_counts[item_to_remove] -= 1
-        self._num_filler_items = max(num_unclaimed_locations, 0)
+        self._num_filler_items = max(num_unclaimed_locations, 0) + self.options.num_legendary_crate_drops.value
 
     def set_rules(self) -> None:
         # Don't require more victories than included characters
@@ -315,12 +310,12 @@ class BrotatoWorld(World):
             loot_crate_groups = self.common_loot_crate_groups
             location_name_template = CRATE_DROP_LOCATION_TEMPLATE
             region_name_template = CRATE_DROP_GROUP_REGION_TEMPLATE
-            item_rule = None
+            progress_type = LocationProgressType.DEFAULT
         else:
             loot_crate_groups = self.legendary_loot_crate_groups
             location_name_template = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE
             region_name_template = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE
-            item_rule = legendary_loot_crate_item_rule
+            progress_type = LocationProgressType.EXCLUDED
 
         regions: List[Region] = []
         crate_count = 1
@@ -332,8 +327,7 @@ class BrotatoWorld(World):
                 crate_location: BrotatoLocation = location_table[crate_location_name].to_location(
                     self.player, parent=group_region
                 )
-                if item_rule is not None:
-                    add_item_rule(crate_location, item_rule)
+                crate_location.progress_type = progress_type
 
                 group_region.locations.append(crate_location)
                 crate_count += 1

--- a/apworld/brotato/rules.py
+++ b/apworld/brotato/rules.py
@@ -1,4 +1,4 @@
-from BaseClasses import CollectionState, Item, ItemClassification
+from BaseClasses import CollectionState
 from worlds.generic.Rules import CollectionRule
 
 from .items import ItemName
@@ -16,16 +16,3 @@ def create_has_character_rule(player: int, character: str) -> CollectionRule:
         return state.has(character, player)
 
     return char_region_access_rule
-
-
-def legendary_loot_crate_item_rule(item: Item) -> bool:
-    """Prevent progression items from being placed at legendary loot crate drops.
-
-    This can cause some very slow/painful BKs if not set
-
-    TODO: Ideally we would make the locations EXCLUDED, but that causes fill problems.
-    """
-    return item.classification not in (
-        ItemClassification.progression,
-        ItemClassification.progression_skip_balancing,
-    )

--- a/apworld/brotato/test/test_include_characters.py
+++ b/apworld/brotato/test/test_include_characters.py
@@ -18,7 +18,7 @@ class TestBrotatoIncludeCharacters(BrotatoTestBase):
         for num_include_characters in range(1, len(CHARACTERS) + 1):
             with self.subTest(msg=f"{num_include_characters=}", n=num_include_characters):
                 include_characters: List[str] = r.sample(CHARACTERS, k=num_include_characters)
-                self.options = {"starting_characters": 1, "include_characters": include_characters}
+                self.options = {"starting_characters": 1, "include_characters": include_characters, "waves_per_drop": 5}
                 self.world_setup()
                 self.test_fill()
                 self.assertBeatable(True)

--- a/apworld/brotato/test/test_items.py
+++ b/apworld/brotato/test/test_items.py
@@ -44,6 +44,7 @@ class TestBrotatoItems(BrotatoTestBase):
     def test_create_items_custom_weight_all_legendary_items(self):
         self._run(
             {
+                "waves_per_drop": 5,  # Increase to have enough locations for all the crates
                 "item_weight_mode": 2,
                 "num_common_crate_drops": 50,
                 "num_legendary_crate_drops": 20,
@@ -61,6 +62,7 @@ class TestBrotatoItems(BrotatoTestBase):
     def test_create_items_custom_weight_legendary_items_weight_zero(self):
         self._run(
             {
+                "waves_per_drop": 5,  # Increase to have enough locations for all the crates
                 "item_weight_mode": 2,
                 "num_common_crate_drops": 50,
                 "num_legendary_crate_drops": 20,


### PR DESCRIPTION
The previous PR added support to decrease the number of checks if there aren't enough locations. This lets us change the legendary loot crate access rule from it's current not-quite-excluded rule to actually excluded, which was the original intent.