### PR TITLE
Have include_characters option check for invalid keys.

### DIFF
--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -152,7 +152,7 @@ class BrotatoWorld(World):
             self.options.num_victories.value,
         )
 
-        # Filter out invalid entries from the option, just in case.
+        # Keep include characters in the defined order to make reading/debugging easier. Entries should all be valid.
         self._include_characters = set()
         for character in CHARACTERS:
             if character in self.options.include_characters:

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -64,6 +64,7 @@ class IncludeCharacters(OptionSet):
 
     default = frozenset(CHARACTERS)
     display_name = "Include Characters"
+    valid_keys = CHARACTERS
 
 
 class WavesPerCheck(Range):

--- a/apworld/brotato/test/test_include_characters.py
+++ b/apworld/brotato/test/test_include_characters.py
@@ -23,20 +23,23 @@ class TestBrotatoIncludeCharacters(BrotatoTestBase):
                 self.test_fill()
                 self.assertBeatable(True)
 
-    def test_include_characters_ignores_invalid_values(self):
+    def test_include_characters_invalid_values_raises_exception(self):
         valid_include_characters = CHARACTERS[:10]
-        invalid_include_characters = ["Jigglypuff", "asdfdadfdasdf", "", "ireallywishihadhypothesisrn"]
-        include_characters = {*valid_include_characters, *invalid_include_characters}
-        self.options = {"starting_characters": 1, "include_characters": include_characters}
-        self.world_setup()
+        invalid_include_characters = [
+            "Well-Rounded",
+            "Bul",
+            "Jigglypuff",
+            "asdfdadfdasdf",
+            "",
+            "ireallywishihadhypothesisrn",
+        ]
 
-        expected_regions = {CHARACTER_REGION_TEMPLATE.format(char=char) for char in valid_include_characters}
-
-        character_regions = {
-            r.name for r in self.multiworld.regions if r.player == self.player and r.name.startswith("In-Game")
-        }
-
-        self.assertSetEqual(expected_regions, character_regions)
+        for invalid_character in invalid_include_characters:
+            with self.subTest(invalid_character=invalid_character):
+                include_characters = {*valid_include_characters, invalid_character}
+                self.options = {"starting_characters": 1, "include_characters": include_characters}
+                # The VerifyKeys mixin on OptionSet raises a bare Exception when it encounters an invalid key.
+                self.assertRaises(Exception, self.world_setup)
 
     def test_include_characters_excluded_characters_do_not_have_regions(self):
         include_characters = CHARACTERS[:10]


### PR DESCRIPTION
alwaysintreble told me there's an actual field on `OptionSet` (technically the `VerifyKeys` mixin), to restrict the entries only to valid keys.

This makes it so we don't need to error check anymore, although we didn't change anything else since we still want the option values in the same order they're defined in `constants.CHARACTERS`, mostly because that's the order I expect to see them in now.