### PR TITLE
Fix item count error and small misc. changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the number of items and locations mismatching with certain option combinations.
+
 ## [0.2.0] - 2024-07-18
 
 ### Added

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -255,7 +255,7 @@ class BrotatoWorld(World):
 
         self.multiworld.itempool += item_pool
 
-    def generate_basic(self) -> None:
+    def pre_fill(self) -> None:
         # Place "Run Won" items at the Run Win event locations
         for character in self._include_characters:
             item: BrotatoItem = self.create_item(ItemName.RUN_COMPLETE)

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -186,7 +186,7 @@ class BrotatoWorld(World):
         # The number of locations available, not including the "Run Won" locations, which always have "Run Won" items.
         num_locations = num_wave_complete_locations + self.options.num_common_crate_drops.value
         num_claimed_locations = (
-            len(self._include_characters)  # For each character unlock
+            (len(self._include_characters) - len(self._starting_characters))  # For each character unlock
             + num_shop_slot_items
             + sum(self._upgrade_and_item_counts.values())
         )
@@ -244,7 +244,7 @@ class BrotatoWorld(World):
             else:
                 item_pool.append(character_item)
 
-        # Create an item for each (Brotato) item and upgrade. This counts are determined in generate_early().
+        # Create an item for each (Brotato) item and upgrade. These counts are determined in generate_early().
         for item_name, item_count in self._upgrade_and_item_counts.items():
             item_pool += [self.create_item(item_name) for _ in range(item_count)]
 

--- a/apworld/brotato/regions.py
+++ b/apworld/brotato/regions.py
@@ -5,6 +5,7 @@ from worlds.generic.Rules import ItemRule, add_item_rule
 
 from . import BrotatoWorld
 from .constants import (
+    CHARACTER_REGION_TEMPLATE,
     CHARACTERS,
     CRATE_DROP_GROUP_REGION_TEMPLATE,
     CRATE_DROP_LOCATION_TEMPLATE,
@@ -55,7 +56,7 @@ def create_regions(world: BrotatoWorld) -> List[Region]:
 
 
 def _create_character_region(world: BrotatoWorld, parent_region: Region, character: str) -> Region:
-    character_region = Region(f"In-Game ({character})", world.player, world.multiworld)
+    character_region = Region(CHARACTER_REGION_TEMPLATE.format(char=character), world.player, world.multiworld)
     character_run_won_location = location_table[RUN_COMPLETE_LOCATION_TEMPLATE.format(char=character)]
     character_region.locations.append(character_run_won_location.to_location(world.player, parent=character_region))
 


### PR DESCRIPTION
I forgot to take the fact that the starting characters won't be in the item pool, which threw off the number of filler items to create leading to generation errors.

This also includes two small fixes (because I'm too lazy to make another PR):

- Change "generate_basic" to "pre_fill" to match AP guidelines
- Use character in-game region template when creating said regions.