### PR TITLE
Fix various issues found while playtesting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a run.
   - Fix: only update the client status to `CLIENT_GOAL` if it is not set.
 - Fix shop lock buttons staying disabled after disconnecting from a multiworld.
+- Fix number of starting shop lock buttons not matching options.
+  - This unfortunately cannot be fixed for existing games, only for ones generated with
+    this fix.
+- Fix upgrades and items received being duplicated across slots if connecting to
+  multiple servers/players in the same game instance.
 
 ## [0.3.0] - 2024-08-15
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The run won icon on the player select screen is now an appropriate size.
 - Removed logs that would cause the game to hang when connecting to a multiworld.
-- Fix game freezing for a few seconds when sending multiple client status updates if
-  connecting after winning a run.
+- Fix game freezing for a few seconds when connecting to a slot after winning a run.
 - Fix shop lock buttons staying disabled after disconnecting from a multiworld.
 - Fix number of starting shop lock buttons not matching options.
   - This unfortunately cannot be fixed for existing games, only for ones generated with

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,9 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The run won icon on the player select screen is now an appropriate size.
 - Removed logs that would cause the game to hang when connecting to a multiworld.
-- Fix mod hanging by sending multiple client status updates if connecting after winning
-  a run.
-  - Fix: only update the client status to `CLIENT_GOAL` if it is not set.
+- Fix game freezing for a few seconds when sending multiple client status updates if
+  connecting after winning a run.
 - Fix shop lock buttons staying disabled after disconnecting from a multiworld.
 - Fix number of starting shop lock buttons not matching options.
   - This unfortunately cannot be fixed for existing games, only for ones generated with

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The run won icon on the player select screen is now an appropriate size.
+- Removed logs that would cause the game to hang when connecting to a multiworld.
+- Fix mod hanging by sending multiple client status updates if connecting after winning
+  a run.
+  - Fix: only update the client status to `CLIENT_GOAL` if it is not set.
+- Fix shop lock buttons staying disabled after disconnecting from a multiworld.
 
 ## [0.3.0] - 2024-08-15
 

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -283,7 +283,7 @@ class BrotatoWorld(World):
             "waves_with_checks": self.waves_with_checks,
             "num_wins_needed": self.options.num_victories.value,
             "num_starting_shop_slots": self.options.num_starting_shop_slots.value,
-            "num_starting_shop_lock_buttons": self.options.num_starting_lock_buttons.value,
+            "num_starting_shop_lock_buttons": (MAX_SHOP_SLOTS - self.num_shop_lock_button_items),
             "num_common_crate_locations": self.options.num_common_crate_drops.value,
             "num_common_crate_drops_per_check": self.options.num_common_crate_drops_per_check.value,
             "common_crate_drop_groups": [asdict(g) for g in self.common_loot_crate_groups],

--- a/apworld/brotato/test/test_slot_data.py
+++ b/apworld/brotato/test/test_slot_data.py
@@ -1,3 +1,4 @@
+from ..options import StartingShopLockButtonsMode
 from . import BrotatoTestBase
 
 
@@ -12,6 +13,8 @@ class TestBrotatoSlotData(BrotatoTestBase):
         "num_legendary_crate_drops_per_check": 1,
         "num_legendary_crate_drop_groups": 2,
         "num_starting_shop_slots": 1,
+        "shop_lock_buttons_mode": StartingShopLockButtonsMode.option_custom,
+        "num_starting_lock_buttons": 2,
         # Use custom item weights so we know that there are exactly 50 common items and 20 legendary items in the
         # itempool when we check the item_waves.
         "item_weight_mode": 2,
@@ -30,6 +33,11 @@ class TestBrotatoSlotData(BrotatoTestBase):
     def test_slot_data_num_starting_shop_slots(self):
         slot_data = self.world.fill_slot_data()
         self.assertEqual(slot_data["num_starting_shop_slots"], 1)
+
+    def test_slot_data_starting_shop_lock_buttons(self):
+        slot_data = self.world.fill_slot_data()
+        # There should be 2 lock button items, and therefore two starting lock buttons
+        self.assertEqual(slot_data["num_starting_shop_lock_buttons"], 2)
 
     def test_slot_data_num_common_crate_locations(self):
         slot_data = self.world.fill_slot_data()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_common.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_common.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" load_steps=4 format=2]
 
-[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_common.png" type="Texture" id=1]
+[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_common.png" type="Texture" id=1]
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=2]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=3]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_legendary.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_legendary.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" load_steps=4 format=2]
 
-[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_legendary.png" type="Texture" id=1]
+[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_legendary.png" type="Texture" id=1]
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=2]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=3]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_rare.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_rare.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" load_steps=4 format=2]
 
-[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_rare.png" type="Texture" id=1]
+[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_rare.png" type="Texture" id=1]
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=2]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=3]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_uncommon.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_gift_items/ap_gift_item_uncommon.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" load_steps=4 format=2]
 
-[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_uncommon.png" type="Texture" id=1]
+[ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_uncommon.png" type="Texture" id=1]
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=2]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=3]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_items_container.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_items_container.gd
@@ -14,7 +14,8 @@ func _ready():
 		self,
 		"_update_lock_buttons"
 	)
-	_update_lock_buttons()
+	if _ap_client.connected_to_multiworld():
+		_update_lock_buttons()
 
 func _update_lock_buttons():
 	for shop_item_idx in range(_shop_items.size()):

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_common.png.import
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_common.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/ap_logo_80_gift_item_common.png-b7d873b9001127490a1d1f71c32bd093.stex"
+path="res://.import/ap_logo_100_gift_item_common.png-c4e8a272148e71e9e4e8ae7a7a6d6ffe.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_common.png"
-dest_files=[ "res://.import/ap_logo_80_gift_item_common.png-b7d873b9001127490a1d1f71c32bd093.stex" ]
+source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_common.png"
+dest_files=[ "res://.import/ap_logo_100_gift_item_common.png-c4e8a272148e71e9e4e8ae7a7a6d6ffe.stex" ]
 
 [params]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_legendary.png.import
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_legendary.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/ap_logo_80_gift_item_legendary.png-79c365397dae27d5e97efcc462a38dfa.stex"
+path="res://.import/ap_logo_100_gift_item_legendary.png-617f2c88cc456e90f51e8abc92735b9e.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_legendary.png"
-dest_files=[ "res://.import/ap_logo_80_gift_item_legendary.png-79c365397dae27d5e97efcc462a38dfa.stex" ]
+source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_legendary.png"
+dest_files=[ "res://.import/ap_logo_100_gift_item_legendary.png-617f2c88cc456e90f51e8abc92735b9e.stex" ]
 
 [params]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_rare.png.import
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_rare.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/ap_logo_80_gift_item_rare.png-99fdfb504d9ee65b21961b65a231c134.stex"
+path="res://.import/ap_logo_100_gift_item_rare.png-659f76c6524dc56fb7891f4979808a31.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_rare.png"
-dest_files=[ "res://.import/ap_logo_80_gift_item_rare.png-99fdfb504d9ee65b21961b65a231c134.stex" ]
+source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_rare.png"
+dest_files=[ "res://.import/ap_logo_100_gift_item_rare.png-659f76c6524dc56fb7891f4979808a31.stex" ]
 
 [params]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_uncommon.png.import
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_uncommon.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/ap_logo_80_gift_item_uncommon.png-cd009a0c775733fa5e974c8c5d4c1448.stex"
+path="res://.import/ap_logo_100_gift_item_uncommon.png-33f5622031cad4c37d7914032ffffba2.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_gift_item_uncommon.png"
-dest_files=[ "res://.import/ap_logo_80_gift_item_uncommon.png-cd009a0c775733fa5e974c8c5d4c1448.stex" ]
+source_file="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_100_gift_item_uncommon.png"
+dest_files=[ "res://.import/ap_logo_100_gift_item_uncommon.png-33f5622031cad4c37d7914032ffffba2.stex" ]
 
 [params]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
@@ -83,6 +83,21 @@ func on_connected_to_multiworld():
 	for tier in wave_per_game_item_json:
 		wave_per_game_item[int(tier)] = wave_per_game_item_json[tier]
 
+	# Clear the received and processed items in case there's data from a previous slot
+	received_items_by_tier = {
+		Tier.COMMON: 0,
+		Tier.UNCOMMON: 0,
+		Tier.RARE: 0,
+		Tier.LEGENDARY: 0
+	}
+
+	processed_items_by_tier = {
+		Tier.COMMON: 0,
+		Tier.UNCOMMON: 0,
+		Tier.RARE: 0,
+		Tier.LEGENDARY: 0
+	}
+
 func on_run_started(_character_id: String):
 	# Reset the number of items processed
 	processed_items_by_tier = {

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -198,6 +198,7 @@ func on_room_updated(updated_room_info: Dictionary):
 func on_connected_to_multiworld():
 	_wins_received = 0
 	location_check_status = {}
+	location_idx_to_id = {}
 	total_checks = _ap_client.slot_data["num_%s_crate_locations" % crate_type]
 	crates_per_check = _ap_client.slot_data["num_%s_crate_drops_per_check" % crate_type]
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -187,7 +187,6 @@ func on_item_received(item_name: String, _item):
 				last_unlocked_group_idx += 1
 				num_unlocked_locations += next_group.num_crates
 				_update_can_spawn_crate()
-				ModLoaderLog.debug("New %s group unlocked. Available checks = %d, Wins needed = %d" % [crate_type, num_unlocked_locations, loot_crate_groups[last_unlocked_group_idx].wins_to_unlock], LOG_NAME)
 
 func on_room_updated(updated_room_info: Dictionary):
 	if updated_room_info.has("checked_locations"):

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/upgrades.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/upgrades.gd
@@ -41,6 +41,15 @@ func on_item_received(item_name: String, _item):
 		# No reason to check if connected or in a run
 		emit_signal("upgrade_received", upgrade_tier)
 
+func on_connected_to_multiworld():
+	# Reset the number of received upgrades in case there's data from a previous slot.
+	received_upgrades_by_tier = {
+		Tier.COMMON: 0,
+		Tier.UNCOMMON: 0,
+		Tier.RARE: 0,
+		Tier.LEGENDARY: 0
+	}
+
 func on_run_started(_character_id: String):
 	# Reset the number of upgrades processed
 	processed_upgrades_by_tier = {

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/wins.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/wins.gd
@@ -10,6 +10,7 @@ class_name ApWinsProgress
 
 var ApTypes = load("res://mods-unpacked/RampagingHippy-Archipelago/ap/ap_types.gd")
 
+var has_won_multiworld: bool = false
 var wins_for_goal: int
 var num_wins: int = 0
 var characters_won_with: PoolStringArray = []
@@ -31,10 +32,15 @@ func _on_wave_finished(wave_number: int, character_id: String, is_run_lost: bool
 func on_item_received(item_name: String, _item):
 	if item_name == "Run Won":
 		num_wins += 1
-		if num_wins >= wins_for_goal:
+		if num_wins >= wins_for_goal and not has_won_multiworld:
 			_ap_client.set_status(ApTypes.ClientStatus.CLIENT_GOAL)
+			# Set this so we don't set the status multiple times when connecting to a won slot.
+			has_won_multiworld = true
 
 func on_connected_to_multiworld():
 	wins_for_goal = _ap_client.slot_data["num_wins_needed"]
 	num_wins = 0
 	characters_won_with = []
+	
+	var client_status  = _ap_client.get_value(["client_status_%d_%d" % [_ap_client.team, _ap_client.slot]])
+	has_won_multiworld = client_status == ApTypes.ClientStatus.CLIENT_GOAL


### PR DESCRIPTION
* Fix slowdowns when connecting to a slot with lots of AP items received:
    * Remove log message in loot crate tracking. It was redundant regardless.
    * Only set the client status to goal if it hasn't been set yet, instead of every time we get a win after having enough.
* Fix slot data giving wrong number of starting shop lock buttons
* Fix upgrades and items received being duplicated across slots if connecting to multiple servers/players in the same game instance.
* Update upgrade and item image paths to use their new names.