### PR TITLE
Fix AP items dropping on health pickups, update mod manifest

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
@@ -4,7 +4,7 @@ class_name GodotApClientDebugSettings
 const LOG_NAME = "RampagingHippy-Archipelago/ap/debug"
 
 # When enabled, drop loot crate every n kills. Referenced in main and item_service.
-var enable_auto_spawn_loot_crate: bool = true
+var enable_auto_spawn_loot_crate: bool = false
 var auto_spawn_loot_crate: bool = false
 var auto_spawn_loot_crate_counter: int = 0
 var auto_spawn_loot_crate_on_count: int = 10

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
@@ -4,9 +4,10 @@ class_name GodotApClientDebugSettings
 const LOG_NAME = "RampagingHippy-Archipelago/ap/debug"
 
 # When enabled, drop loot crate every n kills. Referenced in main and item_service.
+var enable_auto_spawn_loot_crate: bool = true
 var auto_spawn_loot_crate: bool = false
-var auto_spawn_loot_crate_counter = 0
-var auto_spawn_loot_crate_on_count = 3
+var auto_spawn_loot_crate_counter: int = 0
+var auto_spawn_loot_crate_on_count: int = 10
 
 func _init():
-	ModLoaderLog.debug("debug_spawn_loot_crate=%s" % auto_spawn_loot_crate, LOG_NAME)
+	ModLoaderLog.debug("debug_spawn_loot_crate=%s" % enable_auto_spawn_loot_crate, LOG_NAME)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -120,16 +120,20 @@ func spawn_consumables(unit: Unit) -> void:
 	# No reason to check if connected to the multiworld, this is vanilla if
 	# we're not connected since the game should never drop ap_pickups otherwise.
 	var consumable_count_start = _consumables.size()
-	if _ap_client.debug.auto_spawn_loot_crate:
+	if _ap_client.debug.enable_auto_spawn_loot_crate:
 		var old_unit_always_drop_consumable = unit.stats.always_drop_consumables
 		if _ap_client.debug.auto_spawn_loot_crate_counter == _ap_client.debug.auto_spawn_loot_crate_on_count:
 			_ap_client.debug.auto_spawn_loot_crate_counter = 0
 			ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
+			# Tell the unit to drop a consumable
 			unit.stats.always_drop_consumables = true
+			# Tell our item_service extension to force the consumable to be a loot crate
+			_ap_client.debug.auto_spawn_loot_crate = true
 		else:
 			_ap_client.debug.auto_spawn_loot_crate_counter += 1
 		.spawn_consumables(unit)
 		unit.stats.always_drop_consumables = old_unit_always_drop_consumable
+		_ap_client.debug.auto_spawn_loot_crate = false
 	else:
 		.spawn_consumables(unit)
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -121,16 +121,15 @@ func spawn_consumables(unit: Unit) -> void:
 	# we're not connected since the game should never drop ap_pickups otherwise.
 	var consumable_count_start = _consumables.size()
 	if _ap_client.debug.enable_auto_spawn_loot_crate:
+		_ap_client.debug.auto_spawn_loot_crate_counter += 1
 		var old_unit_always_drop_consumable = unit.stats.always_drop_consumables
-		if _ap_client.debug.auto_spawn_loot_crate_counter == _ap_client.debug.auto_spawn_loot_crate_on_count:
+		if _ap_client.debug.auto_spawn_loot_crate_counter >= _ap_client.debug.auto_spawn_loot_crate_on_count:
 			_ap_client.debug.auto_spawn_loot_crate_counter = 0
 			ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
 			# Tell the unit to drop a consumable
 			unit.stats.always_drop_consumables = true
 			# Tell our item_service extension to force the consumable to be a loot crate
 			_ap_client.debug.auto_spawn_loot_crate = true
-		else:
-			_ap_client.debug.auto_spawn_loot_crate_counter += 1
 		.spawn_consumables(unit)
 		unit.stats.always_drop_consumables = old_unit_always_drop_consumable
 		_ap_client.debug.auto_spawn_loot_crate = false

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -142,8 +142,12 @@ func spawn_consumables(unit: Unit) -> void:
 		var spawned_consumable_id = _consumables.back().consumable_data.my_id
 		if spawned_consumable_id == "ap_pickup":
 			_ap_client.common_loot_crate_progress.notify_crate_spawned()
+			# Increment this to help the game calculate drops appropriately. They do the
+			# same for normal loot crate drops.
+			_items_spawned_this_wave += 1
 		elif spawned_consumable_id == "ap_legendary_pickup":
 			_ap_client.legendary_loot_crate_progress.notify_crate_spawned()
+			_items_spawned_this_wave += 1
 
 func on_consumable_picked_up(consumable: Node, player_index: int) -> void:
 	var is_ap_consumable = false

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
@@ -1,23 +1,54 @@
 extends "res://singletons/item_service.gd"
 
 const LOG_NAME = "RampagingHippy-Archipelago/item_service"
+const ITEM_BOX_ID = "consumable_item_box"
+const LEGENDARY_ITEM_BOX_ID = "consumable_legendary_item_box"
 
 var _ap_normal_consuamble = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_pickup/ap_pickup.tres")
 var _ap_legendary_consumable = preload("res://mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_legendary_pickup/ap_legendary_pickup.tres")
 
+
 onready var _ap_client
+onready var _base_game_item_box
+onready var _base_game_legendary_item_box
 
 func _ready():
 	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
 	_ap_client = mod_node.brotato_ap_client
 
+	for consumable in consumables:
+		if consumable.my_id == ITEM_BOX_ID:
+			_base_game_item_box = consumable
+		elif consumable.my_id == LEGENDARY_ITEM_BOX_ID:
+			_base_game_legendary_item_box = consumable
+
 func get_consumable_for_tier(tier: int = Tier.COMMON) -> ConsumableData:
-	if tier == Tier.LEGENDARY and _ap_client.legendary_loot_crate_progress.can_spawn_consumable:
-		return _ap_legendary_consumable.duplicate()
-	elif _ap_client.common_loot_crate_progress.can_spawn_consumable:
-		return _ap_normal_consuamble.duplicate()
+	# Have the game choose what it would spawn first then check it. If it's a
+	# crate drop, and we have space for an AP drop, replace it with the
+	# corresponding AP consumable.
+	# This is only called when the game would actually spawn a consumable, which
+	# makes this the earliest possible place we can override the behavior. This
+	# is good; it means we have to change the minimum real game behavior.
+	# Further, this call is only getting the data about what to spawn, the
+	# actual instance is created later, so we can just drop the original return
+	# value if necessary without hurting anything.
+	var consumable
+	if _ap_client.debug.enable_auto_spawn_loot_crate and _ap_client.debug.auto_spawn_loot_crate:
+		# Debug tool is tellng is to forcibly drop an item box, ignore base game path
+		if tier == Tier.LEGENDARY:
+			consumable = _base_game_legendary_item_box
+		else:
+			consumable = _base_game_item_box
 	else:
-		return .get_consumable_for_tier(tier)	
+		consumable = .get_consumable_for_tier(tier)
+
+	# Replace with corrsponding AP item if possible
+	if _ap_client.common_loot_crate_progress.can_spawn_consumable and consumable.my_id == ITEM_BOX_ID:
+		return _ap_normal_consuamble.duplicate()
+	elif _ap_client.legendary_loot_crate_progress.can_spawn_consumable and consumable.my_id == LEGENDARY_ITEM_BOX_ID:
+		return _ap_legendary_consumable.duplicate()
+	else:
+		return consumable
 
 func process_item_box(consumable_data: ConsumableData, wave: int, player_index: int) -> ItemParentData:
 	match consumable_data.my_id:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Archipelago",
 	"namespace": "RampagingHippy",
-	"version_number": "0.0.1",
+	"version_number": "0.5.0",
 	"description": "Archipelago MultiWorld Client",
 	"website_url": "https://github.com/SpenserHaddad/BrotatoArchipelago",
 	"dependencies": [],
@@ -12,10 +12,10 @@
 				"Spenser Haddad"
 			],
 			"compatible_mod_loader_version": [
-				"3.0.0"
+				"6.0.0"
 			],
 			"compatible_game_version": [
-				"0.6.1.6"
+				"1.1.0.0"
 			],
 			"config_defaults": {}
 		}

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/hud/ap_hud_loot_crate_progress.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/hud/ap_hud_loot_crate_progress.gd
@@ -2,7 +2,10 @@ extends PanelContainer
 
 const CHECK_COMPLETE_FADEOUT_TIME_SEC = 2.0
 const CHECK_COMPLETE_FADEOUT_START_ALPHA = 0.8
+const ENABLED_MODULATE_COLOR = Color.white
+const DISABLED_MODULATE_COLOR = Color.darkslategray
 
+onready var _ap_icon_texture = $HBoxContainer/MarginContainer/ApIconTexture 
 onready var _crate_texture = $HBoxContainer/MarginContainer/CrateTexture
 onready var _progress_label: Label = $HBoxContainer/ProgressLabel
 onready var _tween: Tween = $Tween
@@ -16,7 +19,7 @@ var _loot_crate_progress
 
 func _ready():
 	stylebox.bg_color = Color("#0000ff00")
-	_timer.connect("timeout", self, "_on_timer_timeout")
+	var _result = _timer.connect("timeout", self, "_on_timer_timeout")
 	
 	add_stylebox_override("panel", stylebox)
 	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
@@ -51,6 +54,16 @@ func update_progress(progress: int, total: int):
 		)
 		var _tween_started = _tween.start()
 		_timer.start()
+
+	var modulate_color = ENABLED_MODULATE_COLOR
+	if _loot_crate_progress.num_locations_checked >= _loot_crate_progress.num_unlocked_locations:
+		# We can't get more checks, make the display grey to indicate that to the player
+		modulate_color = DISABLED_MODULATE_COLOR
+
+	_ap_icon_texture.modulate = modulate_color	
+	_crate_texture.modulate = modulate_color
+	_progress_label.modulate = modulate_color
+
 
 func _on_timer_timeout():
 	update_progress(_loot_crate_progress.check_progress, _loot_crate_progress.crates_per_check)


### PR DESCRIPTION
Fixes some regressions introduced with the 0.5.0 update. Users noted that they were getting AP items they shouldn't have access to yet, and that fruit (health) drops were also being replaced with AP items.

Finally remembered to update the mod manifest so the proper version is shown in the in-game mods list.

Updated the health pickup HUDs in-game to dim when there's no more checks available, as a helper to indicate when checks should stop dropping.

Internally, also fixed some naming and logic with the debug loot crate drops to make it clearer, not drop items on fruit, and fix an off-by-one error.