### PR TITLE
Update path to parent node for AP button on main menu

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
@@ -32,7 +32,7 @@ func _ready():
 	_set_ap_button_icon(_ap_websocket_connection.connection_state)
 
 func _add_ap_button():
-	var parent_node: Container = $HBoxContainer/ButtonsLeft
+	var parent_node: Container = $MarginContainer/VBoxContainer/HBoxContainer/ButtonsLeft
 
 	ModLoaderMod.append_node_in_scene(
 		self,


### PR DESCRIPTION
The path changed in Brotato's 1.1.7.1 patch (branch name is wrong, oops). Just needed to update it, everything else is working as intended.