### PR TITLE
Fix wins required bug and incorrect character categorization, with mitigation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   available characters if the Abyssal Terrors DLC was not enabled.
 - HOTFIX: If the game detects the above bug when loaded, it will set the number of wins
   required to 44 so the game is winnable. This will likely be removed in a later patch.
+- The "Starting Characters" option is now a `Choice` instead of a `TextChoice`, so
+  user-defined values are no longer accepted (which was always the intent).
 
 ## [0.5.2] - 2023-11-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Baby, Vagabond, Technomage, and Vampire are now all properly categorized as base game
+  characters when generating games.
+- Fixed a bug where the game could require more wins to goal than the number of
+  available characters if the Abyssal Terrors DLC was not enabled.
+- HOTFIX: If the game detects the above bug when loaded, it will set the number of wins
+  required to 44 so the game is winnable. This will likely be removed in a later patch.
+
 ## [0.5.2] - 2023-11-23
 
 ### Fixed

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -192,6 +192,13 @@ class BrotatoWorld(World):
             if not game_packs[ABYSSAL_TERRORS_CHARACTERS.name][0]:
                 raise OptionError("Abyssal Terrors DLC is not enabled in options.")
             self._starting_characters = self._get_valid_random_characters([ABYSSAL_TERRORS_CHARACTERS])
+        else:
+            raise RuntimeError("Unsupported option!")
+
+        # Clamp the number of wins needed to goal to the number of included characters, so the game isn't unwinnable.
+        # Note that we need to actually change the option value, not just clamp it, otherwise other parts of the world
+        # will miss it. This has caused bugs in the past.
+        self.options.num_victories.value = min(self.options.num_victories.value, len(self._include_characters))
 
         # Initialize the number of upgrades and items to include, then adjust as necessary below.
         self._upgrade_and_item_counts = {
@@ -248,10 +255,8 @@ class BrotatoWorld(World):
         self._num_filler_items = max(num_unclaimed_locations, 0) + self.options.num_legendary_crate_drops.value
 
     def set_rules(self) -> None:
-        # Don't require more victories than included characters
-        num_required_victories = min(self.options.num_victories.value, len(self._include_characters))
         self.multiworld.completion_condition[self.player] = create_has_run_wins_rule(
-            self.player, num_required_victories
+            self.player, self.options.num_victories.value
         )
 
     def create_regions(self) -> None:

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -143,9 +143,8 @@ MAX_LEGENDARY_CRATE_DROPS = 50
 
 # THe maximum number of groups is the maximum number of crates, otherwise we'd have
 # groups which could never be filled.
-# DEBUG: Remove TOTAL_NUM_CHARACTERS BELOW!!
-MAX_NORMAL_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS  # MAX_NORMAL_CRATE_DROPS
-MAX_LEGENDARY_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS  # MAX_LEGENDARY_CRATE_DROPS
+MAX_NORMAL_CRATE_DROP_GROUPS = MAX_NORMAL_CRATE_DROPS
+MAX_LEGENDARY_CRATE_DROP_GROUPS = MAX_LEGENDARY_CRATE_DROPS
 
 # Weights to use when generating Brotato items using the "default item weights" option. These weights are intended to
 # match the rarity of each tier in the vanilla game. The distribution is not explicitly defined in the game, but we can

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -143,8 +143,9 @@ MAX_LEGENDARY_CRATE_DROPS = 50
 
 # THe maximum number of groups is the maximum number of crates, otherwise we'd have
 # groups which could never be filled.
-MAX_NORMAL_CRATE_DROP_GROUPS = MAX_NORMAL_CRATE_DROPS
-MAX_LEGENDARY_CRATE_DROP_GROUPS = MAX_LEGENDARY_CRATE_DROPS
+#DEBUG: Remove TOTAL_NUM_CHARACTERS BELOW!!
+MAX_NORMAL_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS #MAX_NORMAL_CRATE_DROPS
+MAX_LEGENDARY_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS #MAX_LEGENDARY_CRATE_DROPS
 
 # Weights to use when generating Brotato items using the "default item weights" option. These weights are intended to
 # match the rarity of each tier in the vanilla game. The distribution is not explicitly defined in the game, but we can

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -96,6 +96,10 @@ BASE_GAME_CHARACTERS = CharacterGroup(
         "Masochist",
         "Knight",
         "Demon",
+        "Baby",
+        "Vagabond",
+        "Technomage",
+        "Vampire",
     ),
     default_characters=("Well Rounded", "Brawler", "Crazy", "Ranger", "Mage"),
 )
@@ -103,10 +107,6 @@ BASE_GAME_CHARACTERS = CharacterGroup(
 ABYSSAL_TERRORS_CHARACTERS = CharacterGroup(
     name="Abyssal Terrors DLC",
     characters=(
-        "Baby",
-        "Vagabond",
-        "Technomage",
-        "Vampire",
         "Sailor",
         "Curious",
         "Builder",
@@ -143,9 +143,9 @@ MAX_LEGENDARY_CRATE_DROPS = 50
 
 # THe maximum number of groups is the maximum number of crates, otherwise we'd have
 # groups which could never be filled.
-#DEBUG: Remove TOTAL_NUM_CHARACTERS BELOW!!
-MAX_NORMAL_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS #MAX_NORMAL_CRATE_DROPS
-MAX_LEGENDARY_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS #MAX_LEGENDARY_CRATE_DROPS
+# DEBUG: Remove TOTAL_NUM_CHARACTERS BELOW!!
+MAX_NORMAL_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS  # MAX_NORMAL_CRATE_DROPS
+MAX_LEGENDARY_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS  # MAX_LEGENDARY_CRATE_DROPS
 
 # Weights to use when generating Brotato items using the "default item weights" option. These weights are intended to
 # match the rarity of each tier in the vanilla game. The distribution is not explicitly defined in the game, but we can

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -138,14 +138,13 @@ TOTAL_NUM_CHARACTERS = len(ALL_CHARACTERS)
 
 MAX_REQUIRED_RUN_WINS = TOTAL_NUM_CHARACTERS
 
-
 MAX_NORMAL_CRATE_DROPS = 50
 MAX_LEGENDARY_CRATE_DROPS = 50
 
-# Since groups are unlocked by winning runs, the maximum number of groups there is the number of characters.
-# So these are just aliases of NUM_CHARACTERS to make them more explicit.
-MAX_NORMAL_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS
-MAX_LEGENDARY_CRATE_DROP_GROUPS = TOTAL_NUM_CHARACTERS
+# THe maximum number of groups is the maximum number of crates, otherwise we'd have
+# groups which could never be filled.
+MAX_NORMAL_CRATE_DROP_GROUPS = MAX_NORMAL_CRATE_DROPS
+MAX_LEGENDARY_CRATE_DROP_GROUPS = MAX_LEGENDARY_CRATE_DROPS
 
 # Weights to use when generating Brotato items using the "default item weights" option. These weights are intended to
 # match the rarity of each tier in the vanilla game. The distribution is not explicitly defined in the game, but we can

--- a/apworld/brotato/constants.py
+++ b/apworld/brotato/constants.py
@@ -151,7 +151,7 @@ MAX_LEGENDARY_CRATE_DROP_GROUPS = MAX_LEGENDARY_CRATE_DROPS
 # make a reasonable guess by looking at the max chances of getting items of each rarity/tier from the shop or loot
 # crates, which are publcially listed here: https://brotato.wiki.spellsandguns.com/Shop#Rarity_of_Shop_Items_and_Luck.
 # We use the values from the "Max Chance" column in the table in the linked sections as weights. It's not perfect, but
-# it "feels" right and seems close enough.s
+# it "feels" right and seems close enough.
 DEFAULT_ITEM_WEIGHTS: Tuple[int, int, int, int] = (100, 60, 25, 8)
 
 MAX_COMMON_UPGRADES = 50

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Choice, OptionSet, PerGameCommonOptions, Range, TextChoice, Toggle
+from Options import Choice, OptionSet, PerGameCommonOptions, Range, Toggle
 
 from .constants import (
     ABYSSAL_TERRORS_CHARACTERS,
@@ -32,7 +32,7 @@ class NumberRequiredWins(Range):
     display_name = "Wins Required"
 
 
-class StartingCharacters(TextChoice):
+class StartingCharacters(Choice):
     """Determines your set of starting characters.
 
     Characters omitted from "Include Characters" will not be included regardless of this option.

--- a/apworld/brotato/test/_data_sets.py
+++ b/apworld/brotato/test/_data_sets.py
@@ -13,11 +13,11 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..constants import (
+    BASE_GAME_CHARACTERS,
     MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
     MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
-    NUM_CHARACTERS,
 )
 
 
@@ -217,7 +217,7 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
         ),
     ),
     BrotatoTestDataSet(
-        description="Max possible groups and crates, more groups than req. wins",
+        description="Max possible groups and crates, more groups than req. wins, no DLC",
         options=BrotatoTestOptions(
             num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
             num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
@@ -225,7 +225,7 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
         ),
         expected_results=BrotatoTestExpectedResults(
-            # The number of groups will be set to 30 when generating.
+            # The number of groups will be set to 30 (default # of wins) when generated.
             num_common_crate_regions=30,
             common_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
             num_legendary_crate_regions=30,
@@ -236,28 +236,29 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
         ),
     ),
     BrotatoTestDataSet(
-        description="Max possible groups and crates",
+        description="Max wins, equal groups to characters, no DLC",
         options=BrotatoTestOptions(
-            num_victories=NUM_CHARACTERS,
+            num_victories=BASE_GAME_CHARACTERS.num_characters,
             num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
-            num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
-            num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
-            num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
+            # Assign one group per character, so each win makes more crates accessible.
+            num_common_crate_drop_groups=BASE_GAME_CHARACTERS.num_characters,
+            num_legendary_crate_drops=BASE_GAME_CHARACTERS.num_characters,
+            num_legendary_crate_drop_groups=BASE_GAME_CHARACTERS.num_characters,
         ),
         expected_results=BrotatoTestExpectedResults(
-            num_common_crate_regions=NUM_CHARACTERS,
-            common_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
-            num_legendary_crate_regions=NUM_CHARACTERS,
-            legendary_crates_per_region=tuple(([2] * 6) + ([1] * 38)),
+            num_common_crate_regions=BASE_GAME_CHARACTERS.num_characters,
+            common_crates_per_region=tuple([1] * 44),
+            num_legendary_crate_regions=BASE_GAME_CHARACTERS.num_characters,
+            legendary_crates_per_region=tuple([1] * 44),
             # Every win will unlock a new crate drop group.
-            wins_required_per_common_region=tuple(range(MAX_NORMAL_CRATE_DROP_GROUPS)),
-            wins_required_per_legendary_region=tuple(range(MAX_LEGENDARY_CRATE_DROP_GROUPS)),
+            wins_required_per_common_region=tuple(range(BASE_GAME_CHARACTERS.num_characters)),
+            wins_required_per_legendary_region=tuple(range(BASE_GAME_CHARACTERS.num_characters)),
         ),
     ),
     BrotatoTestDataSet(
         description="Max number of crates, one group",
         options=BrotatoTestOptions(
-            num_victories=NUM_CHARACTERS,
+            num_victories=BASE_GAME_CHARACTERS.num_characters,
             num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,

--- a/apworld/brotato/test/test_include_characters.py
+++ b/apworld/brotato/test/test_include_characters.py
@@ -4,8 +4,9 @@ from typing import List
 from BaseClasses import PlandoOptions, Region
 from Options import OptionError
 
-from ..constants import CHARACTER_REGION_TEMPLATE, CHARACTERS, DEFAULT_CHARACTERS
+from ..constants import BASE_GAME_CHARACTERS, CHARACTER_REGION_TEMPLATE
 from ..items import ItemName
+from ..options import StartingCharacters
 from . import BrotatoTestBase
 
 
@@ -16,16 +17,16 @@ class TestBrotatoIncludeCharacters(BrotatoTestBase):
         # Which characters we pick to include shouldn't matter, just the amount. But let's randomize who we pick each
         # time just in case.
         r = random.Random(0x7A70)
-        for num_include_characters in range(1, len(CHARACTERS) + 1):
+        for num_include_characters in range(1, BASE_GAME_CHARACTERS.num_characters + 1):
             with self.subTest(msg=f"{num_include_characters=}", n=num_include_characters):
-                include_characters: List[str] = r.sample(CHARACTERS, k=num_include_characters)
+                include_characters: List[str] = r.sample(BASE_GAME_CHARACTERS.characters, k=num_include_characters)
                 self.options = {"starting_characters": 1, "include_characters": include_characters, "waves_per_drop": 5}
                 self.world_setup()
                 self.test_fill()
                 self.assertBeatable(True)
 
     def test_include_characters_invalid_values_raises_exception(self):
-        valid_include_characters = CHARACTERS[:10]
+        valid_include_characters = BASE_GAME_CHARACTERS.characters[:10]
         invalid_include_characters = [
             "Well-Rounded",
             "Bul",
@@ -38,25 +39,25 @@ class TestBrotatoIncludeCharacters(BrotatoTestBase):
         for invalid_character in invalid_include_characters:
             with self.subTest(invalid_character=invalid_character):
                 include_characters = {*valid_include_characters, invalid_character}
-                self.options = {"starting_characters": 1, "include_characters": include_characters}
+                self.options = {"starting_characters": 1, "include_base_game_characters": include_characters}
                 # The VerifyKeys mixin on OptionSet raises a bare Exception when it encounters an invalid key.
                 self.world_setup()
                 self.assertRaises(
                     OptionError,
-                    self.world.options.include_characters.verify,
+                    self.world.options.include_base_game_characters.verify,
                     self.world,
                     self.world.player_name,
                     PlandoOptions.none,
                 )
 
     def test_include_characters_excluded_characters_do_not_have_regions(self):
-        include_characters = CHARACTERS[:10]
-        self.options = {"starting_characters": 1, "include_characters": include_characters}
+        include_characters = BASE_GAME_CHARACTERS.characters[:10]
+        self.options = {"starting_characters": 1, "include_base_game_characters": include_characters}
         self.world_setup()
 
         player_regions: dict[str, Region] = {r.name: r for r in self.multiworld.regions if r.player == self.player}
 
-        for character in CHARACTERS:
+        for character in BASE_GAME_CHARACTERS.characters:
             character_region_name = CHARACTER_REGION_TEMPLATE.format(char=character)
             if character in include_characters:
                 self.assertIn(character_region_name, player_regions)
@@ -64,22 +65,35 @@ class TestBrotatoIncludeCharacters(BrotatoTestBase):
                 self.assertNotIn(character_region_name, player_regions)
 
     def test_include_characters_excludes_default_characters(self):
-        include_characters = set(CHARACTERS)
+        """Test that excluded characters are not in the starting pool if they would be
+        otherwise.
+
+        Essentially testing that "starting_characters" and "include_*_characters"
+        options interact as expected.
+        """
+        include_characters = set(BASE_GAME_CHARACTERS.characters)
         include_characters.remove("Brawler")
-        expected_starting_characters = set(DEFAULT_CHARACTERS)
+        expected_starting_characters = set(BASE_GAME_CHARACTERS.default_characters)
         expected_starting_characters.remove("Brawler")
 
-        self.options = {"starting_characters": 0, "include_characters": include_characters}
+        self.options = {
+            "starting_characters": StartingCharacters.option_default_base_game,
+            "include_base_game_characters": include_characters,
+        }
         self.world_setup()
 
         player_precollected = self.multiworld.precollected_items[self.player]
-        precollected_characters = {p.name for p in player_precollected if p.name in CHARACTERS}
+        precollected_characters = {p.name for p in player_precollected if p.name in BASE_GAME_CHARACTERS.characters}
 
         self.assertSetEqual(precollected_characters, expected_starting_characters)
 
     def test_include_characters_less_characters_than_wins_changes_goal(self):
-        include_characters = set(DEFAULT_CHARACTERS)
-        self.options = {"starting_characters": 1, "include_characters": include_characters, "wins_required": 30}
+        include_characters = set(BASE_GAME_CHARACTERS.default_characters)
+        self.options = {
+            "starting_characters": 1,
+            "include_base_game_characters": include_characters,
+            "wins_required": 30,
+        }
         self.world_setup()
 
         self.assertFalse(self.multiworld.has_beaten_game(self.multiworld.state))

--- a/apworld/brotato/test/test_num_victories.py
+++ b/apworld/brotato/test/test_num_victories.py
@@ -1,0 +1,33 @@
+from ..constants import BASE_GAME_CHARACTERS
+from . import BrotatoTestBase
+
+
+class TestBrotatoNumVictoriesOption(BrotatoTestBase):
+    """Test edge cases related to the num_victories option."""
+
+    def test_num_victories_clamped_to_number_of_characters(self):
+        """Test that the number of victories is not more than the number of included characters.
+
+        This prevents unwinnable situtations where there aren't enough characters to reach the goal with.
+
+        We also check the output slot data to make sure the change, if made, propagates to it as well.
+        """
+        expected_final_num_victories_value = BASE_GAME_CHARACTERS.num_characters - 5
+        include_characters = BASE_GAME_CHARACTERS.characters[
+            :expected_final_num_victories_value
+        ]
+        original_num_victories_value = BASE_GAME_CHARACTERS.num_characters
+
+        options = {
+            "num_victories": original_num_victories_value,
+            "include_base_game_characters": include_characters,
+        }
+
+        self._run(options)
+
+        final_num_victories_value = self.world.options.num_victories.value
+        # Checking slot data here so we don't need to duplicate the test setup in multiple functions/files.
+        slot_data_num_victories = self.world.fill_slot_data()["num_wins_needed"]
+
+        self.assertEqual(expected_final_num_victories_value, final_num_victories_value)
+        self.assertEqual(expected_final_num_victories_value, slot_data_num_victories)

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union
 
 from ..constants import (
-    CHARACTERS,
+    BASE_GAME_CHARACTERS,
     CRATE_DROP_GROUP_REGION_TEMPLATE,
     CRATE_DROP_LOCATION_TEMPLATE,
     LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE,
@@ -132,7 +132,7 @@ class TestBrotatoRegions(BrotatoTestBase):
                     ),
                 )
 
-                next_character_won = CHARACTERS[character_index]
+                next_character_won = BASE_GAME_CHARACTERS.characters[character_index]
                 character_index += 1
                 next_win_location = self.world.get_location(
                     RUN_COMPLETE_LOCATION_TEMPLATE.format(char=next_character_won)

--- a/apworld/brotato/test/test_starting_characters.py
+++ b/apworld/brotato/test/test_starting_characters.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from ..constants import CHARACTERS, DEFAULT_CHARACTERS
+from ..constants import BASE_GAME_CHARACTERS
 from ..items import item_name_groups
 from . import BrotatoTestBase
 
@@ -40,16 +40,12 @@ class TestBrotatoStartingCharacters(BrotatoTestBase):
 
     def test_default_starting_characters(self):
         self._run_and_check(
-            num_characters=len(DEFAULT_CHARACTERS),
+            num_characters=BASE_GAME_CHARACTERS.num_default_characters,
             custom_starting_characters=False,
-            expected_characters=DEFAULT_CHARACTERS,
+            expected_characters=BASE_GAME_CHARACTERS.default_characters,
         )
 
-    # TODO: Probably can't use pytest.paramterize, is there a better way?
     def test_custom_starting_characters(self):
-        for num_characters in range(1, len(CHARACTERS)):
+        for num_characters in range(1, BASE_GAME_CHARACTERS.num_characters):
             with self.subTest(msg=f"{num_characters} starting characters"):
                 self._run_and_check(num_characters=num_characters)
-
-        with self.subTest(msg=f"{len(CHARACTERS)} starting characters"):
-            self._run_and_check(num_characters=len(CHARACTERS), expected_characters=CHARACTERS)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/wins.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/wins.gd
@@ -65,13 +65,6 @@ func on_connected_to_multiworld():
 		if wins_for_goal > ap_world_num_base_game_characters:
 			ModLoaderLog.warning("Bug detected, not enough characters to win with without DLC. Updating value", LOG_NAME)
 			wins_for_goal = ap_world_num_base_game_characters
-#	var chars_in_world = []
-#	for character in ItemService.characters:
-#		var character_won_loc_name = constants.RUN_COMPLETE_LOCATION_TEMPLATE.format({"char": character})
-#		if character_won_loc_name in _ap_client.data_package.location_name_to_id:
-#			chars_in_world.append(character)
-#	ModLoaderLog.debug("Characters Available: %s" % ", ".join(chars_in_world), LOG_NAME)
-#	ModLoaderLog.debug("Number of wins: %d, number of characters in world: %d" % [wins_for_goal, chars_in_world.size()], LOG_NAME)
-	
+
 	var client_status  = _ap_client.get_value(["client_status_%d_%d" % [_ap_client.team, _ap_client.slot]])
 	has_won_multiworld = client_status == ApTypes.ClientStatus.CLIENT_GOAL


### PR DESCRIPTION
This fixes two issues:

* Baby, Vagabond, Technomage, and Vampire were all incorrectly labeled as being part of the Abyssal Terrors characters, instead of the base game (they were added in the 1.1.0.0 update that also added the DLC). This has been corrected.
* Fixed an issue where the number of wins required to win in the slot data was set to higher than the number of available characters if the DLC characters were excluded.
    * We had worked around this in the apworld when creating the `Victory` rule by clamping the number of wins to the number of included characters, but this was not propagated to other parts of the code, and the original option was not changed. As a result, slot data used the option's value which may be impossible to reach.
    * The apworld now updates the `num_victories` option value to be the minimum of the given value and the total number of available characters.
* Added a fix for the above to allow games generated with impossible settings to still complete.
    * We detect if a game is connected without the DLC, but with more wins needed than is possible with the base game (excluding the four incorrectly categorized characters). If so, we clamp the number of wins to the number of characters.
    * If the DLC is enabled, we're still guaranteed to have enough characters regardless of the `num_victories` value.

There's also some test code cleanup that got caught in the changes, and one fix to the `starting_characters` option to make it a `Choice` instead of a `TextChoice`, so user-defined values are no longer acceptable (they never should have been.