### PR TITLE
Fix game crashing due to Brotato updating to Godot 3.6

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -25,7 +25,14 @@ func _ready() -> void:
 	
 	if _ap_client.connected_to_multiworld():
 		if RunData.current_wave == DebugService.starting_wave:
-			# Run started, notify the AP game state tracker
+			# Run started, notify the AP game state tracker.
+			
+			# Wait a very short time before sending the notify_run_started event to
+			# ensure the rest of the game is initialized. As of the 1.1.8.0 patch,
+			# collecting enough XP to level up too early causes the game to crash
+			# because the "Level Up" floating text is not fully initialized yet. This
+			# isn't elegant, but it doesn't negatively impact UX and it works.
+			yield(get_tree().create_timer(0.01), "timeout")
 			var active_characters = []
 			for player in RunData.players_data:
 				active_characters.append(player.current_character.my_id)
@@ -66,6 +73,12 @@ func _ready() -> void:
 			"res://mods-unpacked/RampagingHippy-Archipelago/ui/menus/hud/ap_hud.tscn",
 			true
 		)
+
+func _start_of_run_update_delay_timer_timeout():
+	var active_characters = []
+	for player in RunData.players_data:
+		active_characters.append(player.current_character.my_id)
+	_ap_client.game_state.notify_run_started(active_characters)
 
 # Archipelago Item received handlers
 func _on_ap_item_received(item_tier: int):

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -74,12 +74,6 @@ func _ready() -> void:
 			true
 		)
 
-func _start_of_run_update_delay_timer_timeout():
-	var active_characters = []
-	for player in RunData.players_data:
-		active_characters.append(player.current_character.my_id)
-	_ap_client.game_state.notify_run_started(active_characters)
-
 # Archipelago Item received handlers
 func _on_ap_item_received(item_tier: int):
 	var item_data

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/waves.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/waves.gd
@@ -17,7 +17,7 @@ func _init(ap_client, game_state).(ap_client, game_state):
 func on_connected_to_multiworld():
 	waves_with_checks = PoolIntArray(_ap_client.slot_data["waves_with_checks"])
 
-func _on_wave_finished(wave_number: int, character_ids: Array, is_run_lost: bool, is_run_won: bool):
+func _on_wave_finished(wave_number: int, character_ids: Array, is_run_lost: bool, _is_run_won: bool):
 	if not is_run_lost and waves_with_checks.has(wave_number):
 		# TODO: check if location was checked already
 		for character_id in character_ids:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/tools/export_image.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/tools/export_image.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://resources/fonts/actual/base/font_big_title.tres" type="DynamicFont" id=1]
+[ext_resource path="res://resources/fonts/actual/base/font_26_outline_thick.tres" type="DynamicFont" id=1]
 [ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_upgrade_arrow_green.png" type="Texture" id=2]
 [ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/tools/export_image.gd" type="Script" id=3]
 [ext_resource path="res://resources/themes/base_theme.tres" type="Theme" id=4]

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
@@ -160,7 +160,7 @@ func _on_ShowPasswordButton_pressed():
 		_password_edit.secret = true
 		_show_password_button.text = "Show"
 		
-func _on_PlayerEdit_text_changed(new_text: String):
+func _on_PlayerEdit_text_changed(_new_text: String):
 	_update_connect_button_disabled()
 
 func _reset_status_texture():


### PR DESCRIPTION
If we call notify_run_started, and there's enough banked XP to level up, the game will crash because it tries to show the level up text before the floating text Scene (specifically, its Tween) is initialized.

This seems to be an implementation detail change in the order of setup operations for Brotato version 1.1.8.0, which updated the game to use Godot 3.6.

The fix added is to just wait 10ms before sending the notification and continuing through `main._ready` to let the rest of the game finish setting up. Not pretty, but it handles the problem well enough, and I couldn't see a better way to do it.

Also added a couple of small fixes caught by Godot as warnings, to reduce log noise. Only the change in `main.gd` is relevant to the fix.