### PR TITLE
Fix unit tests

### DIFF
--- a/apworld/brotato/test/_data_sets.py
+++ b/apworld/brotato/test/_data_sets.py
@@ -236,10 +236,10 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
         ),
     ),
     BrotatoTestDataSet(
-        description="Max wins, equal groups to characters, no DLC",
+        description="Max wins, one crate per character, one group per character, no DLC",
         options=BrotatoTestOptions(
             num_victories=BASE_GAME_CHARACTERS.num_characters,
-            num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
+            num_common_crate_drops=BASE_GAME_CHARACTERS.num_characters,
             # Assign one group per character, so each win makes more crates accessible.
             num_common_crate_drop_groups=BASE_GAME_CHARACTERS.num_characters,
             num_legendary_crate_drops=BASE_GAME_CHARACTERS.num_characters,
@@ -247,9 +247,9 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
         ),
         expected_results=BrotatoTestExpectedResults(
             num_common_crate_regions=BASE_GAME_CHARACTERS.num_characters,
-            common_crates_per_region=tuple([1] * 44),
+            common_crates_per_region=tuple([1] * BASE_GAME_CHARACTERS.num_characters),
             num_legendary_crate_regions=BASE_GAME_CHARACTERS.num_characters,
-            legendary_crates_per_region=tuple([1] * 44),
+            legendary_crates_per_region=tuple([1] * BASE_GAME_CHARACTERS.num_characters),
             # Every win will unlock a new crate drop group.
             wins_required_per_common_region=tuple(range(BASE_GAME_CHARACTERS.num_characters)),
             wins_required_per_legendary_region=tuple(range(BASE_GAME_CHARACTERS.num_characters)),

--- a/apworld/brotato/test/test_items.py
+++ b/apworld/brotato/test/test_items.py
@@ -2,7 +2,7 @@ from collections import Counter
 
 from ..constants import MAX_SHOP_SLOTS
 from ..items import ItemName
-from ..options import StartingShopLockButtonsMode
+from ..options import ItemWeights, StartingShopLockButtonsMode
 from . import BrotatoTestBase
 
 
@@ -25,7 +25,14 @@ class TestBrotatoItems(BrotatoTestBase):
 
         for test_item_rarity, expected_populated_item in item_rarity_prefix_to_name.items():
             with self.subTest(msg=test_item_rarity):
-                options = {"item_weight_mode": 2, "num_common_crate_drops": 50, "num_legendary_crate_drops": 0}
+                options = {
+                    "item_weight_mode": ItemWeights.option_custom,
+                    "num_common_crate_drops": 50,
+                    "num_legendary_crate_drops": 0,
+                    # Set the number of waves per drop to the max to ensure generate_early doesn't try to reduce the
+                    # number of crates.
+                    "waves_per_drop": 1,
+                }
                 for rarity_prefix in item_rarity_prefix_to_name:
                     item_weight_option = f"{rarity_prefix}_item_weight"
                     item_weight = 100 if rarity_prefix == test_item_rarity else 0
@@ -41,7 +48,8 @@ class TestBrotatoItems(BrotatoTestBase):
                     else:
                         expected_amount = 0
 
-                    self.assertEqual(item_counts[self.world.create_item(item_name)], expected_amount)
+                    world_item_count = item_counts[self.world.create_item(item_name)]
+                    self.assertEqual(world_item_count, expected_amount)
 
     def test_create_items_custom_weight_all_legendary_items(self):
         self._run(

--- a/apworld/brotato/test/test_regions.py
+++ b/apworld/brotato/test/test_regions.py
@@ -134,9 +134,12 @@ class TestBrotatoRegions(BrotatoTestBase):
 
                 next_character_won = BASE_GAME_CHARACTERS.characters[character_index]
                 character_index += 1
-                next_win_location = self.world.get_location(
-                    RUN_COMPLETE_LOCATION_TEMPLATE.format(char=next_character_won)
-                )
+                try:
+                    next_win_location = self.world.get_location(
+                        RUN_COMPLETE_LOCATION_TEMPLATE.format(char=next_character_won)
+                    )
+                except KeyError:
+                    self.fail(f"Character {next_character_won} does not have a Run Won location.")
                 old_num_wins = self.multiworld.state.count(run_won_item_name, self.player)
                 # Set event=True so the state doesn't try to collect more wins and throw off our tests
                 self.multiworld.state.collect(run_won_item, prevent_sweep=True, location=next_win_location)


### PR DESCRIPTION
Fix some unit tests that broke as part of the Abyssal Terrors-related updates. Most of these stem from the fact that 4 new characters were added to the base game in the update, which threw off some math.

There is still one outstanding case where some region-based tests fail when the full AP test suite is run. I'm not sure what causes this yet, but it's not worth putting more effort into at this moment.