### PR TITLE
Add mod configuration file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added configuration file for the client mod to save some settings outside of the game.
+  - The configuration file is located at
+    `%APPDATA%/configs/RampagingHippy-Archipelago/ap_config.json`.
+- The last used server, player name, and password are now all saved to the configuration
+  file when successfully connecting to a server, and are loaded from the file when
+  opening the game.
+
 ## [0.5.4] - 2024-12-21
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
@@ -112,6 +112,7 @@ func disconnect_from_server():
 	_client.disconnect_from_host()
 
 func send_connect(game: String, user: String, password: String="", slot_data: bool=true):
+	ModLoaderLog.info("Sending Connect command, game=%s, user=%s, has_pw=%b" % [game, user, password.empty()], LOG_NAME)
 	_send_command({
 		"cmd": "Connect",
 		"game": game,
@@ -125,9 +126,11 @@ func send_connect(game: String, user: String, password: String="", slot_data: bo
 	})
 
 func send_sync():
+	ModLoaderLog.info("Sending Sync command", LOG_NAME)
 	_send_command({"cmd": "Sync"})
 
 func send_location_checks(locations: Array):
+	ModLoaderLog.info("Sending LocationChecks command", LOG_NAME)
 	_send_command(
 		{
 			"cmd": "LocationChecks",

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd
@@ -38,7 +38,7 @@ var wins_progress
 
 signal on_connection_refused(reasons)
 
-func _init(websocket_client).(websocket_client):
+func _init(websocket_client, config).(websocket_client, config):
 	self.game = "Brotato"
 	game_state = ApBrotatoGameState.new(self)
 	character_progress = ApCharacterProgress.new(self, game_state)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/godot_ap_client.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/godot_ap_client.gd
@@ -62,8 +62,9 @@ class ApDataPackage:
 var websocket_client
 var config
 var connect_state = ConnectState.DISCONNECTED
-var player: String = ""
 var server: String = "archipelago.gg"
+var player: String = ""
+var password: String = ""
 var game: String = ""
 
 var team: int
@@ -96,6 +97,7 @@ func _init(websocket_client_, config_):
 	# Load last used connection info from the configuration
 	server = config.data["ap_server"]
 	player = config.data["ap_player"]
+	password = config.data["ap_password"]
 
 func _ready():
 	var _status: int
@@ -107,7 +109,7 @@ func _ready():
 func _connected_or_connection_refused_received(message: Dictionary):
 	emit_signal("_received_connect_response", message)
 
-func connect_to_multiworld(password: String="", get_data_pacakge: bool=true) -> int:
+func connect_to_multiworld(get_data_pacakge: bool=true) -> int:
 	## Connect to the multiworld using the host/port/player/password provided.
 	##
 	## NOTE: The game, server, and player fields for the class MUST be set before

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/godot_ap_client.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/godot_ap_client.gd
@@ -60,6 +60,7 @@ class ApDataPackage:
 			location_id_to_name[location_id] = location_name
 
 var websocket_client
+var config
 var connect_state = ConnectState.DISCONNECTED
 var player: String = ""
 var server: String = "archipelago.gg"
@@ -89,8 +90,12 @@ signal data_storage_updated(key, new_value, original_value)
 ## Emitted when a `RoomUpdate` packet is received. Contains the new room information.
 signal room_updated(updated_room_info)
 
-func _init(websocket_client_):
-	self.websocket_client = websocket_client_
+func _init(websocket_client_, config_):
+	websocket_client = websocket_client_
+	config = config_
+	# Load last used connection info from the configuration
+	server = config.data["ap_server"]
+	player = config.data["ap_player"]
 
 func _ready():
 	var _status: int
@@ -221,6 +226,14 @@ func connect_to_multiworld(password: String="", get_data_pacakge: bool=true) -> 
 	#    connection.
 
 	_set_connection_state(ConnectState.CONNECTED_TO_MULTIWORLD)
+	
+	# Mod-specific: Save the connection parameters in the configuration file so
+	# the user doesn't need to enter them twice.
+	config.data["ap_server"] = server
+	config.data["ap_player"] = player
+	config.data["ap_password"] = password
+	ModLoaderConfig.update_config(config)
+	
 	return ConnectResult.SUCCESS
 
 func disconnect_from_multiworld():

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
@@ -47,6 +47,11 @@
 						"type": "string",
 						"minLength": 0,
 						"default": ""
+					},
+					"has_saved_run": {
+						"title": "Archipelago Last Run Was Saved",
+						"type": "boolean",
+						"default": "false"
 					}
 				}
 			}

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
@@ -51,7 +51,7 @@
 					"has_saved_run": {
 						"title": "Archipelago Last Run Was Saved",
 						"type": "boolean",
-						"default": "false"
+						"default": false
 					}
 				}
 			}

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/manifest.json
@@ -17,7 +17,39 @@
 			"compatible_game_version": [
 				"1.1.0.0"
 			],
-			"config_defaults": {}
+			"config_schema": {
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"title": "Archipelago Config",
+				"description": "Configuration for the Archipelago Client mod",
+				"type": "object",
+				"properties": {
+					"ap_server": {
+						"title": "Archipelago Server",
+						"type": "string",
+						"anyOf": [
+							{"format": "hostname"},
+							{"format": "idn-hostname"},
+							{"format": "ipv4"},
+							{"format": "ipv6"}
+						],
+						"minLength": 1,
+						"default": "archipelago.gg"
+					},
+					"ap_player": {
+						"title": "Archipelago Player",
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 16,
+						"default": "Player"
+					},
+					"ap_password": {
+						"title": "Archipelago Password",
+						"type": "string",
+						"minLength": 0,
+						"default": ""
+					}
+				}
+			}
 		}
 	}
 }

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -7,7 +7,7 @@ const MOD_VERSION = "0.5.4"
 const LOG_NAME = MOD_NAME + "/mod_main"
 
 const ApWebSocketConnection = preload("res://mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd")
-const BrotatoApClient = preload("res://mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd")
+var BrotatoApClient = load("res://mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd")
 
 export onready var ap_websocket_connection
 export onready var brotato_ap_client
@@ -52,10 +52,17 @@ func _ready() -> void:
 
 	# TODO: Can we turn the service into a singleton somehow? Adding a node to the root
 	# didn't seem to work.
+
+	var config = ModLoaderConfig.get_config(MOD_NAME, "ap_config")
+	if config == null:
+		var default_config = ModLoaderConfig.get_default_config(MOD_NAME)
+		ModLoaderConfig.create_config(MOD_NAME, "ap_config", default_config.data)
+		config = ModLoaderConfig.get_config(MOD_NAME, "ap_config")
+
 	ap_websocket_connection = ApWebSocketConnection.new()
 	self.add_child(ap_websocket_connection)
 
-	brotato_ap_client = BrotatoApClient.new(ap_websocket_connection)
+	brotato_ap_client = BrotatoApClient.new(ap_websocket_connection, config)
 	self.add_child(brotato_ap_client)
 
 	ModLoaderLog.success("Archipelago mod v%s initialized" % MOD_VERSION, LOG_NAME)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -50,9 +50,7 @@ func _ready() -> void:
 	# ModLoaderLog.info(str("Translation Demo: ", tr("MODNAME_READY_TEXT")), LOG_NAME)
 	# ModLoaderLog.success("Loaded", LOG_NAME)
 
-	# TODO: Can we turn the service into a singleton somehow? Adding a node to the root
-	# didn't seem to work.
-
+	# TODO: Config migrations, add version number and check for matching values.
 	var config = ModLoaderConfig.get_config(MOD_NAME, "ap_config")
 	if config == null:
 		var default_config = ModLoaderConfig.get_default_config(MOD_NAME)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/menu_ap_connect.gd
@@ -33,8 +33,10 @@ func _ready():
 	_ap_client = mod_node.brotato_ap_client
 	_ap_client.connect("connection_state_changed", self, "_on_connection_state_changed")
 
+	# Set connection values to whatever the client has, in case they loaded a config.
 	_host_edit.text = _ap_client.server
 	_player_edit.text = _ap_client.player
+	_password_edit.text = _ap_client.password
 
 	_on_connection_state_changed(_ap_client.connect_state)
 
@@ -141,9 +143,10 @@ func _update_connect_button_disabled():
 func _on_ConnectButton_pressed():
 	_ap_client.server = _host_edit.text
 	_ap_client.player = _player_edit.text
+	_ap_client.password = _password_edit.text
  
 	# Fire and forget this coroutine call, signal handlers will take care of the rest.
-	_ap_client.connect_to_multiworld(_password_edit.text)
+	_ap_client.connect_to_multiworld()
 
 func _on_BackButton_pressed():
 	emit_signal("back_button_pressed")


### PR DESCRIPTION
Add configuration file via the ModLoaderConfiguration API. This stores the last used connection credentials, and the last run used in AP.

There's also a config value to check if the last AP run was saved partway through, with the idea that we can support resuming runs eventually. This isn't ready to go yet, so all the code related to it is disabled for now.