### PR TITLE
New options for gold and XP rewards, and for disabling enemy XP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new option `enable_enemy_xp`, which controls whether enemies will grant XP when
+  killed.
+- Added new option `gold_reward_mode`, which controls how gold items are given to the
+  player. This has two values:
+    - `one_time` (`0`): Gold items are only given to the player once per game. This is
+      the same behavior as in previous versions.
+    - `all_every_time` (`1`): At the start of each run, the player is given ALL gold
+      received.
+- Added new option `xp_reward_mode`, which controls how XP items are given to the
+  player. This has two values:
+    - `one_time` (`0`): XP items are only given to the player once per game. This is
+      the same behavior as in previous versions.
+    - `all_every_time` (`1`): At the start of each run, the player is given ALL XP
+      received.
+
+
 ## [0.6.0] - 2025-01-12
 
 ### Added

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -4,9 +4,10 @@ from dataclasses import asdict
 from typing import Any, ClassVar, Dict, List, Literal, Set, Tuple, Union
 
 from BaseClasses import Item, LocationProgressType, MultiWorld, Region, Tutorial
-from Options import OptionError
+from Options import OptionError, OptionGroup
 from worlds.AutoWorld import WebWorld, World
 
+from . import options  # So we don't need to import every option class when defining option groups
 from ._loot_crate_groups import BrotatoLootCrateGroup, build_loot_crate_groups
 from .constants import (
     ABYSSAL_TERRORS_CHARACTERS,
@@ -54,6 +55,48 @@ class BrotatoWeb(WebWorld):
     ]
     theme = "dirt"
     rich_text_options_doc = True
+
+    option_groups = [
+        OptionGroup(
+            "Loot Crates",
+            [
+                options.SpawnNormalLootCrates,
+                options.NumberCommonCrateDropLocations,
+                options.NumberCommonCrateDropsPerCheck,
+                options.NumberCommonCrateDropGroups,
+                options.NumberLegendaryCrateDropLocations,
+                options.NumberLegendaryCrateDropsPerCheck,
+                options.NumberLegendaryCrateDropGroups,
+            ],
+        ),
+        OptionGroup(
+            "Item Rewards",
+            [
+                options.ItemWeights,
+                options.CommonItemWeight,
+                options.UncommonItemWeight,
+                options.RareItemWeight,
+                options.LegendaryItemWeight,
+            ],
+        ),
+        OptionGroup(
+            "Upgrades",
+            [
+                options.NumberCommonUpgrades,
+                options.NumberUncommonUpgrades,
+                options.NumberRareUpgrades,
+                options.NumberLegendaryUpgrades,
+            ],
+        ),
+        OptionGroup(
+            "Shop Slots",
+            [options.StartingShopSlots, options.StartingShopLockButtonsMode, options.NumberStartingShopLockButtons],
+        ),
+        OptionGroup(
+            "Abyssal Terrors DLC",
+            [options.EnableAbyssalTerrorsDLC, options.IncludeAbyssalTerrorsCharacters],
+        ),
+    ]
 
 
 class BrotatoWorld(World):

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -352,11 +352,19 @@ class BrotatoWorld(World):
         return self.random.choice(self._filler_items)
 
     def fill_slot_data(self) -> Dict[str, Any]:
+        # Define outside dict for readability
+        spawn_normal_loot_crates = (
+            self.options.spawn_normal_loot_crates.value == self.options.spawn_normal_loot_crates.option_true
+        )
         return {
             "waves_with_checks": self.waves_with_checks,
             "num_wins_needed": self.options.num_victories.value,
+            "gold_reward_mode": self.options.gold_reward_mode.value,
+            "xp_reward_mode": self.options.xp_reward_mode.value,
+            "enable_enemy_xp": self.options.enable_enemy_xp.value == self.options.enable_enemy_xp.option_true,
             "num_starting_shop_slots": self.options.num_starting_shop_slots.value,
             "num_starting_shop_lock_buttons": (MAX_SHOP_SLOTS - self.num_shop_lock_button_items),
+            "spawn_normal_loot_crates": spawn_normal_loot_crates,
             "num_common_crate_locations": self.options.num_common_crate_drops.value,
             "num_common_crate_drops_per_check": self.options.num_common_crate_drops_per_check.value,
             "common_crate_drop_groups": [asdict(g) for g in self.common_loot_crate_groups],

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -100,6 +100,39 @@ class WavesPerCheck(Range):
     display_name = "Waves Per Check"
 
 
+class GoldRewardMode(Choice):
+    """Chooses how gold rewards are given.
+
+    #. One Time
+       Gold items are only given once, in either the current run or the next run after receiving the item.
+    #. All Every Time
+        The total amount of gold received is given to the player at the start of every run. Since gold is a filler item,
+        this can lead to the game being "won" very easily early on in larger multiworlds.
+    """
+
+    option_one_time = 0
+    option_all_every_time = 1
+
+    default = 0
+    display_name = "Gold Reward Mode"
+
+
+class XpRewardMode(Choice):
+    """Chooses how XP rewards are given.
+
+    #. One Time
+       XP items are only given once, in either the current run or the next run after receiving the item.
+    #. All Every Time
+        The total amount of XP received is given to the player at the start of every run.
+    """
+
+    option_one_time = 0
+    option_all_every_time = 1
+
+    default = 1
+    display_name = "XP Reward Mode"
+
+
 class NumberCommonCrateDropLocations(Range):
     """Replaces the in-game loot crate drops with an Archipelago item which must be picked up to generate a check.
 
@@ -189,6 +222,19 @@ class NumberLegendaryCrateDropGroups(Range):
 
     default = 1
     display_name: str = "Legendary Loot Crate Groups"
+
+
+class SpawnNormalLootCrates(Toggle):
+    """Sets whether loot crates can still spawn when connected to a multiworld.
+
+    If off, then the only consumables that spawn will be the health items and the Archipelago drop item. No regular or
+    legendary loot crates will spawn.
+
+    If on, then loot crates will still spawn when there are no available Archipelago drops. See 'Loot Crate Groups' for
+    details.
+    """
+
+    display_name = "Spawn Non-AP Loot Crates Enable"
 
 
 class ItemWeights(Choice):
@@ -373,12 +419,15 @@ class BrotatoOptions(PerGameCommonOptions):
     include_base_game_characters: IncludeBaseGameCharacters
     num_starting_characters: NumberStartingCharacters
     waves_per_drop: WavesPerCheck
+    gold_reward_mode: GoldRewardMode
+    xp_reward_mode: XpRewardMode
     num_common_crate_drops: NumberCommonCrateDropLocations
     num_common_crate_drops_per_check: NumberCommonCrateDropsPerCheck
     num_common_crate_drop_groups: NumberCommonCrateDropGroups
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
     num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
     num_legendary_crate_drop_groups: NumberLegendaryCrateDropGroups
+    spawn_normal_loot_crates: SpawnNormalLootCrates
     item_weight_mode: ItemWeights
     common_item_weight: CommonItemWeight
     uncommon_item_weight: UncommonItemWeight

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -125,7 +125,7 @@ class XpRewardMode(Choice):
     option_one_time = 0
     option_all_every_time = 1
 
-    default = 1
+    default = 0
     display_name = "XP Reward Mode"
 
 

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -103,11 +103,9 @@ class WavesPerCheck(Range):
 class GoldRewardMode(Choice):
     """Chooses how gold rewards are given.
 
-    #. One Time
-       Gold items are only given once, in either the current run or the next run after receiving the item.
-    #. All Every Time
-        The total amount of gold received is given to the player at the start of every run. Since gold is a filler item,
-        this can lead to the game being "won" very easily early on in larger multiworlds.
+    #. One Time: Gold items are only given once, in either the current run or the next run after receiving the item.
+    #. All Every Time: The total amount of gold received is given to the player at the start of every run. Since gold is
+       a filler item, this can lead to the game being "won" very easily early on in larger multiworlds.
     """
 
     option_one_time = 0
@@ -120,10 +118,8 @@ class GoldRewardMode(Choice):
 class XpRewardMode(Choice):
     """Chooses how XP rewards are given.
 
-    #. One Time
-       XP items are only given once, in either the current run or the next run after receiving the item.
-    #. All Every Time
-        The total amount of XP received is given to the player at the start of every run.
+    #. One Time: XP items are only given once, in either the current run or the next run after receiving the item.
+    #. All Every Time: The total amount of XP received is given to the player at the start of every run.
     """
 
     option_one_time = 0
@@ -131,6 +127,29 @@ class XpRewardMode(Choice):
 
     default = 1
     display_name = "XP Reward Mode"
+
+
+class EnableEnemyXp(Toggle):
+    """Sets enemies will give XP or not.
+
+    If disabled, enemies will not give XP. The only XP will be from XP items in the multiworld. Upgrades will be from
+    leveling up and upgrade items received.
+    """
+
+    display_name = "Enable Enemy XP"
+
+
+class SpawnNormalLootCrates(Toggle):
+    """Sets whether loot crates can still spawn when connected to a multiworld.
+
+    If off, then the only consumables that spawn will be the health items and the Archipelago drop item. No regular or
+    legendary loot crates will spawn.
+
+    If on, then loot crates will still spawn when there are no available Archipelago drops. See 'Loot Crate Groups' for
+    details.
+    """
+
+    display_name = "Spawn Normal Loot Crates"
 
 
 class NumberCommonCrateDropLocations(Range):
@@ -222,19 +241,6 @@ class NumberLegendaryCrateDropGroups(Range):
 
     default = 1
     display_name: str = "Legendary Loot Crate Groups"
-
-
-class SpawnNormalLootCrates(Toggle):
-    """Sets whether loot crates can still spawn when connected to a multiworld.
-
-    If off, then the only consumables that spawn will be the health items and the Archipelago drop item. No regular or
-    legendary loot crates will spawn.
-
-    If on, then loot crates will still spawn when there are no available Archipelago drops. See 'Loot Crate Groups' for
-    details.
-    """
-
-    display_name = "Spawn Non-AP Loot Crates Enable"
 
 
 class ItemWeights(Choice):
@@ -421,13 +427,14 @@ class BrotatoOptions(PerGameCommonOptions):
     waves_per_drop: WavesPerCheck
     gold_reward_mode: GoldRewardMode
     xp_reward_mode: XpRewardMode
+    enable_enemy_xp: EnableEnemyXp
+    spawn_normal_loot_crates: SpawnNormalLootCrates
     num_common_crate_drops: NumberCommonCrateDropLocations
     num_common_crate_drops_per_check: NumberCommonCrateDropsPerCheck
     num_common_crate_drop_groups: NumberCommonCrateDropGroups
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
     num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
     num_legendary_crate_drop_groups: NumberLegendaryCrateDropGroups
-    spawn_normal_loot_crates: SpawnNormalLootCrates
     item_weight_mode: ItemWeights
     common_item_weight: CommonItemWeight
     uncommon_item_weight: UncommonItemWeight

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/brotato_ap_client.gd
@@ -11,6 +11,7 @@ var ApBrotatoGameState = load("res://mods-unpacked/RampagingHippy-Archipelago/ap
 var ApCharacterProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/characters.gd")
 var ApShopSlotsProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/shop_slots.gd")
 var ApShopLockButtonsProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/shop_lock_buttons.gd")
+var ApEnemyXpProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/enemy_xp.gd")
 var ApGoldProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/gold.gd")
 var ApXpProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd")
 var ApItemsProgress = load("res://mods-unpacked/RampagingHippy-Archipelago/progress/items.gd")
@@ -27,6 +28,7 @@ var debug
 var character_progress
 var shop_slots_progress
 var shop_lock_buttons_progress
+var enemy_xp_progress
 var gold_progress
 var xp_progress
 var items_progress
@@ -44,6 +46,7 @@ func _init(websocket_client, config).(websocket_client, config):
 	character_progress = ApCharacterProgress.new(self, game_state)
 	shop_slots_progress = ApShopSlotsProgress.new(self, game_state)
 	shop_lock_buttons_progress = ApShopLockButtonsProgress.new(self, game_state)
+	enemy_xp_progress = ApEnemyXpProgress.new(self, game_state)
 	gold_progress = ApGoldProgress.new(self, game_state)
 	xp_progress = ApXpProgress.new(self, game_state)
 	items_progress = ApItemsProgress.new(self, game_state)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/constants.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/constants.gd
@@ -108,6 +108,16 @@ const XP_ITEM_NAME_TO_VALUE = {
 	"XP (150)": 150,
 }
 
+enum GoldRewardMode {
+	ONE_TIME = 0
+	ALL_EVERY_TIME = 1
+}
+
+enum XpRewardMode {
+	ONE_TIME = 0
+	ALL_EVERY_TIME = 1
+}
+
 func _init():
 	for char_name in CHARACTER_NAME_TO_ID:
 		var char_id = CHARACTER_NAME_TO_ID[char_name]

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/run_data.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/run_data.gd
@@ -5,6 +5,16 @@ onready var _ap_client
 func _ready() -> void:
 	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
 	_ap_client = mod_node.brotato_ap_client
+	var _status = _ap_client.xp_progress.connect("xp_received", self, "_on_ap_xp_received")
+	_status = _ap_client.gold_progress.connect("gold_received", self, "_on_ap_gold_received")
+
+func _on_ap_xp_received(amount: int):
+	for player_index in RunData.get_player_count():
+		add_xp(amount, player_index, true)
+
+func _on_ap_gold_received(amount: int):
+	for player_index in RunData.get_player_count():
+		add_gold(amount, player_index)
 
 func add_xp(value: int, player_index: int, is_ap_xp: bool = false) -> void:
 	# Only add XP if the AP client says so, or if it's an AP item. The enemy XP progress

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/run_data.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/run_data.gd
@@ -1,0 +1,13 @@
+extends "res://singletons/run_data.gd"
+
+onready var _ap_client
+
+func _ready() -> void:
+	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
+	_ap_client = mod_node.brotato_ap_client
+
+func add_xp(value: int, player_index: int, is_ap_xp: bool = false) -> void:
+	# Only add XP if the AP client says so, or if it's an AP item. The enemy XP progress
+	# class also checks if we're connected to a multiworld.
+	if _ap_client.enemy_xp_progress.enable_enemy_xp or is_ap_xp:
+		.add_xp(value, player_index)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -21,6 +21,7 @@ func _init():
 	# Add extensions
 	var extension_files = [
 		"main.gd", # Update consumable drop logic to spawn AP items
+		"singletons/run_data.gd", # Override XP rewards
 		"singletons/item_service.gd", # Drop AP consumables
 		"ui/menus/pages/main_menu.gd", # Add AP connect
 		# Detect when game is quit when the "Return to main menu" confirmation button is pressed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd
@@ -50,9 +50,14 @@ func on_room_updated(_room_update: Dictionary):
 func on_connected_to_multiworld():
 	pass
 
+func on_disconnected_from_multiworld():
+	pass
+
 func on_run_started(_character_ids: Array):
 	pass
 
 func _on_client_connection_state_changed(state: int, _error: int=0):
 	if state == GodotApClient.ConnectState.CONNECTED_TO_MULTIWORLD:
 		on_connected_to_multiworld()
+	elif state == GodotApClient.ConnectState.DISCONNECTED:
+		on_disconnected_from_multiworld()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/enemy_xp.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/enemy_xp.gd
@@ -1,0 +1,31 @@
+## Track if enemies can give XP to the player.
+##
+## This really just checks if we're connected to a multiworld and, if so, the value of
+## the `enable_enemy_xp` slot data entry. This corresponds directly to the value of the
+## "Enable Enemy XP" option in the apworld. If we're connected and the flag is False,
+## then enemy XP rewards are intercepted and disabled.
+##
+## This is referenced by our override of RunData.add_xp to check if XP should be awarded
+## or not. We put the logic for checking the slot here for consistency with the rest of
+## the mod. The progress handlers are the only place slot data is checked currently,
+## which seems like a good convention to maintain.
+extends "res://mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd"
+class_name ApEnemyXpProgress
+
+const LOG_NAME = "RampagingHippy-Archipelago/progress/enemy_xp"
+
+# Enable enemy XP (vanilla behavior) until we're connected to a multiworld.
+var enable_enemy_xp = true
+
+func _init(ap_client, game_state).(ap_client, game_state):
+	pass
+
+func on_connected_to_multiworld():
+	# Reset received XP. As the multiworld sends us all our received items we'll
+	# recalculate the received XP.
+	enable_enemy_xp = _ap_client.slot_data["enable_enemy_xp"]
+	ModLoaderLog.info("enable_enemy_xp set to %s" % enable_enemy_xp, LOG_NAME)
+
+func on_disconnected_from_multiworld():
+	# Disconnected, set the flag to true
+	enable_enemy_xp = true

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/enemy_xp.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/enemy_xp.gd
@@ -21,9 +21,10 @@ func _init(ap_client, game_state).(ap_client, game_state):
 	pass
 
 func on_connected_to_multiworld():
-	# Reset received XP. As the multiworld sends us all our received items we'll
-	# recalculate the received XP.
-	enable_enemy_xp = _ap_client.slot_data["enable_enemy_xp"]
+	# Check the slot data to see if enemies should give XP. Legacy behavior is
+	# to just set the value to true.
+	if _ap_client.slot_data.has("enable_enemy_xp"):
+		enable_enemy_xp = _ap_client.slot_data["enable_enemy_xp"]
 	ModLoaderLog.info("enable_enemy_xp set to %s" % enable_enemy_xp, LOG_NAME)
 
 func on_disconnected_from_multiworld():

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
@@ -29,7 +29,7 @@ func give_player_unreceived_xp():
 		var xp_to_give = xp_received - xp_given
 		if xp_to_give > 0:
 			for player_idx in RunData.get_player_count():
-				RunData.add_xp(xp_to_give, player_idx)
+				RunData.add_xp(xp_to_give, player_idx, true)
 			_ap_client.set_value(
 				_received_xp_data_storage_key,
 				"add",

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
@@ -12,8 +12,17 @@
 extends "res://mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd"
 class_name ApXpProgress
 
+const LOG_NAME = "RampagingHippy-Archipelago/progress/xp"
+
+signal xp_received
+
+# The total XP received from items, given or not given.
 var xp_received: int = 0
+
+# The XP given to the player, which is either per run or per game depending on
+# the player's settings.
 var xp_given: int = 0
+var xp_reward_mode: int = 0
 var _received_xp_data_storage_key: String = ""
 
 func _init(ap_client, game_state).(ap_client, game_state):
@@ -28,15 +37,21 @@ func give_player_unreceived_xp():
 	if _game_state.is_in_ap_run():
 		var xp_to_give = xp_received - xp_given
 		if xp_to_give > 0:
-			for player_idx in RunData.get_player_count():
-				RunData.add_xp(xp_to_give, player_idx, true)
-			_ap_client.set_value(
-				_received_xp_data_storage_key,
-				"add",
-				xp_to_give,
-				0,
-				true
-			)
+			emit_signal("xp_received", xp_to_give)
+
+			if xp_reward_mode == constants.XpRewardMode.ONE_TIME:
+				# Send the gold received to the server so we don't give the
+				# player this gold again
+				_ap_client.set_value(
+					_received_xp_data_storage_key,
+					"add",
+					xp_to_give,
+					0,
+					true
+				)
+			else:
+				# Store the tracked gold locally
+				xp_given += xp_to_give
 
 func on_item_received(item_name: String, _item):
 	if item_name in constants.XP_ITEM_NAME_TO_VALUE:
@@ -47,8 +62,17 @@ func on_connected_to_multiworld():
 	# Reset received XP. As the multiworld sends us all our received items we'll
 	# recalculate the received XP.
 	xp_received = 0
+
+	if _ap_client.slot_data.has("xp_reward_mode"):
+		xp_reward_mode = _ap_client.slot_data["xp_reward_mode"]
+		ModLoaderLog.debug("XP reward mode is %d" % xp_reward_mode, LOG_NAME)
+	else:
+		xp_reward_mode = constants.XpRewardMode.ONE_TIME
+		ModLoaderLog.debug("Legacy mode, XP reward mode is one_time.", LOG_NAME)
+
+	# Initialize the data storage value if it wasn't set yet. Do this regardless of
+	# whether we'll use it for simplicity.
 	_received_xp_data_storage_key = "%s_xp_given" % _ap_client.player
-	# Initialize the data storage value if it wasn't set yet
 	_ap_client.set_value(
 		_received_xp_data_storage_key,
 		"default",
@@ -58,6 +82,9 @@ func on_connected_to_multiworld():
 	)
 
 func on_run_started(_character_ids: Array):
+	if xp_reward_mode == constants.XpRewardMode.ALL_EVERY_TIME:
+		# Reset the received XP so we give the player all gold items again.
+		xp_given = 0
 	give_player_unreceived_xp()
 
 func _on_session_data_storage_updated(key: String, new_value, _original_value = null):


### PR DESCRIPTION
Also sorted the options into option groups (seemed as good a time as any). All the other changes on the apworld side are to add the options and pass them into the slot data. There's no logic for these options yet, but there maybe should be.

Most of the work is client side, adding a new progress handler for enemy XP and updating the gold/XP handlers to account for the new reward type. I also moved the code for giving the gold and XP to a `RunData` overload, to make Godot happier about the typing when we overloaded `add_xp`.