### PR TITLE
Handle the lock item event directly so using the hotkey for locking doesn't work.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix it being possible to lock shop slots without the appropriate shop lock AP item by
+  using the controller/keyboard button bound to lock items instead of pressing the UI
+  button.
+
 ## [0.7.0] - 2025-01-23
 
 ### Added

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_item.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_item.gd
@@ -14,6 +14,15 @@ func manage_lock_button_visibility() -> void:
 		# Trust that the game has set the lock button properly, just set the text back
 		# in case we changed it before and received an lock button item from AP.
 		_lock_button.text = "MENU_LOCK"
-
 	
-		
+
+func change_lock_status(button_pressed: bool) -> void:
+	# Intercept the call to lock/unlock the item and discard if we don't have the item.
+	# Even thugh we disable the button, this can still be triggered by a button press.
+	if ap_lock_button_enabled:
+		.change_lock_status(button_pressed)
+	else:
+		var old_text = _lock_button.text
+		_lock_button.text = "NOPE"
+		yield(get_tree().create_timer(0.5), "timeout")
+		_lock_button.text = old_text


### PR DESCRIPTION
Disabling the lock button isn't enough to keep players from locking shop items without the appropriate AP item. Since there's a button that can be pressed to also toggle the lock, we need to check the lock status at the point where both code paths converge.

We still keep the old code to disable the UI button because it looks nice.