### PR TITLE
Add better shop slot/lock button tests, and new logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added more logging to the lock shop slot button-related logic to try and track down a
+  recurring issue where the buttons are disabled despite starting options.
+
+
 ## [0.7.1] - 2025-01-28
 
 ### Fixed

--- a/apworld/brotato/test/__init__.py
+++ b/apworld/brotato/test/__init__.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 from test.bases import WorldTestBase
 
 from .. import BrotatoWorld
-from ._data_sets import TEST_DATA_SETS
+from .data_sets.loot_crates import TEST_DATA_SETS
 
 
 class BrotatoTestBase(WorldTestBase):

--- a/apworld/brotato/test/data_sets/loot_crates.py
+++ b/apworld/brotato/test/data_sets/loot_crates.py
@@ -12,7 +12,7 @@ reason it couldn't be expanded to handle more in the future.
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from ..constants import (
+from ...constants import (
     BASE_GAME_CHARACTERS,
     MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
@@ -22,7 +22,7 @@ from ..constants import (
 
 
 @dataclass(frozen=True)
-class BrotatoTestOptions:
+class BrotatoLootCrateTestOptions:
     """Subset of the full options that we want to control for the test, with defaults.
 
     This avoids needing to specify all the options for the dataclass, and makes using it in the tests slightly more
@@ -37,7 +37,7 @@ class BrotatoTestOptions:
 
 
 @dataclass(frozen=True)
-class BrotatoTestExpectedResults:
+class BrotatoLootCrateTestExpectedResults:
     # An int value means all regions have the same number of crates.
     # A tuple of ints means region "Crate Group {i}" has number of crates in index [i]
     num_common_crate_regions: int
@@ -86,9 +86,9 @@ class BrotatoTestExpectedResults:
 
 
 @dataclass(frozen=True)
-class BrotatoTestDataSet:
-    options: BrotatoTestOptions
-    expected_results: BrotatoTestExpectedResults
+class BrotatoLootCrateTestDataSet:
+    options: BrotatoLootCrateTestOptions
+    expected_results: BrotatoLootCrateTestExpectedResults
     description: Optional[str] = None
 
     def test_name(self) -> str:
@@ -113,16 +113,16 @@ class BrotatoTestDataSet:
         return asdict(self.options)
 
 
-TEST_DATA_SETS: List[BrotatoTestDataSet] = [
-    BrotatoTestDataSet(
+TEST_DATA_SETS: List[BrotatoLootCrateTestDataSet] = [
+    BrotatoLootCrateTestDataSet(
         description="Easily divisible, common and legendary same (25 crates)",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=25,
             num_common_crate_drop_groups=5,
             num_legendary_crate_drops=25,
             num_legendary_crate_drop_groups=5,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=5,
             common_crates_per_region=5,
             num_legendary_crate_regions=5,
@@ -131,15 +131,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0, 6, 12, 18, 24),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Easily divisible, common and legendary same (30 crates)",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=30,
             num_common_crate_drop_groups=6,
             num_legendary_crate_drops=30,
             num_legendary_crate_drop_groups=6,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=6,
             common_crates_per_region=5,
             num_legendary_crate_regions=6,
@@ -148,15 +148,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Easily divisible, common and legendary are different",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=20,
             num_common_crate_drop_groups=2,
             num_legendary_crate_drops=30,
             num_legendary_crate_drop_groups=6,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=2,
             common_crates_per_region=10,
             num_legendary_crate_regions=6,
@@ -165,15 +165,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0, 5, 10, 15, 20, 25),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Unequal groups",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=16,
             num_common_crate_drop_groups=3,
             num_legendary_crate_drops=16,
             num_legendary_crate_drop_groups=3,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=3,
             common_crates_per_region=(6, 5, 5),
             num_legendary_crate_regions=3,
@@ -182,15 +182,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0, 10, 20),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Unequal groups, common and legendary are different",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=35,
             num_common_crate_drop_groups=15,
             num_legendary_crate_drops=25,
             num_legendary_crate_drop_groups=5,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             # Five "3's" and ten "2's", because the drops don't evenly divide into the groups
             num_common_crate_regions=15,
             common_crates_per_region=tuple(([3] * 5) + ([2] * 10)),
@@ -216,15 +216,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0, 6, 12, 18, 24),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Max possible groups and crates, more groups than req. wins, no DLC",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
             num_common_crate_drop_groups=MAX_NORMAL_CRATE_DROP_GROUPS,
             num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_legendary_crate_drop_groups=MAX_LEGENDARY_CRATE_DROP_GROUPS,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             # The number of groups will be set to 30 (default # of wins) when generated.
             num_common_crate_regions=30,
             common_crates_per_region=tuple(([2] * 20) + ([1] * 10)),
@@ -235,9 +235,9 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=tuple(range(30)),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Max wins, one crate per character, one group per character, no DLC",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_victories=BASE_GAME_CHARACTERS.num_characters,
             num_common_crate_drops=BASE_GAME_CHARACTERS.num_characters,
             # Assign one group per character, so each win makes more crates accessible.
@@ -245,7 +245,7 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             num_legendary_crate_drops=BASE_GAME_CHARACTERS.num_characters,
             num_legendary_crate_drop_groups=BASE_GAME_CHARACTERS.num_characters,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=BASE_GAME_CHARACTERS.num_characters,
             common_crates_per_region=tuple([1] * BASE_GAME_CHARACTERS.num_characters),
             num_legendary_crate_regions=BASE_GAME_CHARACTERS.num_characters,
@@ -255,16 +255,16 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=tuple(range(BASE_GAME_CHARACTERS.num_characters)),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Max number of crates, one group",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_victories=BASE_GAME_CHARACTERS.num_characters,
             num_common_crate_drops=MAX_NORMAL_CRATE_DROPS,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=1,
             common_crates_per_region=50,
             num_legendary_crate_regions=1,
@@ -274,15 +274,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0,),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="1 crate and 1 group",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=1,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=1,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=1,
             common_crates_per_region=1,
             num_legendary_crate_regions=1,
@@ -291,15 +291,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0,),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="2 crates, 1 group",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=2,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=2,
             num_legendary_crate_drop_groups=1,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=1,
             common_crates_per_region=2,
             num_legendary_crate_regions=1,
@@ -308,15 +308,15 @@ TEST_DATA_SETS: List[BrotatoTestDataSet] = [
             wins_required_per_legendary_region=(0,),
         ),
     ),
-    BrotatoTestDataSet(
+    BrotatoLootCrateTestDataSet(
         description="Max number of crates, 1 common group, 2 legendary groups",
-        options=BrotatoTestOptions(
+        options=BrotatoLootCrateTestOptions(
             num_common_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_common_crate_drop_groups=1,
             num_legendary_crate_drops=MAX_LEGENDARY_CRATE_DROPS,
             num_legendary_crate_drop_groups=2,
         ),
-        expected_results=BrotatoTestExpectedResults(
+        expected_results=BrotatoLootCrateTestExpectedResults(
             num_common_crate_regions=1,
             common_crates_per_region=50,
             num_legendary_crate_regions=2,

--- a/apworld/brotato/test/data_sets/shop_slots.py
+++ b/apworld/brotato/test/data_sets/shop_slots.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from itertools import product
+
+from ...constants import MAX_SHOP_SLOTS
+from ...options import StartingShopLockButtonsMode
+
+
+@dataclass(frozen=True)
+class ShopSlotsTestCase:
+    num_starting_shop_slots: int
+    lock_button_mode: StartingShopLockButtonsMode
+    num_starting_lock_buttons: int
+    expected_num_starting_lock_buttons: int
+
+    @property
+    def expected_num_shop_slot_items(self) -> int:
+        return MAX_SHOP_SLOTS - self.num_starting_shop_slots
+
+    @property
+    def expected_num_lock_button_items(self) -> int:
+        return MAX_SHOP_SLOTS - self.expected_num_starting_lock_buttons
+
+
+SHOP_SLOT_TEST_DATA_SETS: list[ShopSlotsTestCase] = []
+
+for num_shop_slots, num_lock_buttons in product(range(MAX_SHOP_SLOTS + 1), range(MAX_SHOP_SLOTS + 1)):
+    # all should always be 4
+    SHOP_SLOT_TEST_DATA_SETS.append(
+        ShopSlotsTestCase(
+            num_starting_shop_slots=num_shop_slots,
+            lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_all),
+            num_starting_lock_buttons=num_lock_buttons,
+            expected_num_starting_lock_buttons=MAX_SHOP_SLOTS,
+        )
+    )
+
+    # none should always be 0
+    SHOP_SLOT_TEST_DATA_SETS.append(
+        ShopSlotsTestCase(
+            num_starting_shop_slots=num_shop_slots,
+            lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_none),
+            num_starting_lock_buttons=num_lock_buttons,
+            expected_num_starting_lock_buttons=0,
+        )
+    )
+
+    # match_shop_slots should disregard num_lock_buttons
+    SHOP_SLOT_TEST_DATA_SETS.append(
+        ShopSlotsTestCase(
+            num_starting_shop_slots=num_shop_slots,
+            lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_match_shop_slots),
+            num_starting_lock_buttons=num_lock_buttons,
+            expected_num_starting_lock_buttons=num_shop_slots,
+        )
+    )
+
+    # custom should ignore num_slots
+    SHOP_SLOT_TEST_DATA_SETS.append(
+        ShopSlotsTestCase(
+            num_starting_shop_slots=num_shop_slots,
+            lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_custom),
+            num_starting_lock_buttons=num_lock_buttons,
+            expected_num_starting_lock_buttons=num_lock_buttons,
+        )
+    )

--- a/apworld/brotato/test/data_sets/shop_slots.py
+++ b/apworld/brotato/test/data_sets/shop_slots.py
@@ -24,42 +24,42 @@ class ShopSlotsTestCase:
 SHOP_SLOT_TEST_DATA_SETS: list[ShopSlotsTestCase] = []
 
 for num_shop_slots, num_lock_buttons in product(range(MAX_SHOP_SLOTS + 1), range(MAX_SHOP_SLOTS + 1)):
-    # all should always be 4
     SHOP_SLOT_TEST_DATA_SETS.append(
         ShopSlotsTestCase(
             num_starting_shop_slots=num_shop_slots,
             lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_all),
             num_starting_lock_buttons=num_lock_buttons,
+            # option_all: Starting lock buttons should always be 4
             expected_num_starting_lock_buttons=MAX_SHOP_SLOTS,
         )
     )
 
-    # none should always be 0
     SHOP_SLOT_TEST_DATA_SETS.append(
         ShopSlotsTestCase(
             num_starting_shop_slots=num_shop_slots,
             lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_none),
             num_starting_lock_buttons=num_lock_buttons,
+            # option_none: Starting lock buttons should always be 0
             expected_num_starting_lock_buttons=0,
         )
     )
 
-    # match_shop_slots should disregard num_lock_buttons
     SHOP_SLOT_TEST_DATA_SETS.append(
         ShopSlotsTestCase(
             num_starting_shop_slots=num_shop_slots,
             lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_match_shop_slots),
             num_starting_lock_buttons=num_lock_buttons,
+            # option_match_shop_slots: Starting lock buttons should disregard num_lock_buttons
             expected_num_starting_lock_buttons=num_shop_slots,
         )
     )
 
-    # custom should ignore num_slots
     SHOP_SLOT_TEST_DATA_SETS.append(
         ShopSlotsTestCase(
             num_starting_shop_slots=num_shop_slots,
             lock_button_mode=StartingShopLockButtonsMode(StartingShopLockButtonsMode.option_custom),
             num_starting_lock_buttons=num_lock_buttons,
+            # option_custom: Starting lock buttons should match num_starting_lock_buttons
             expected_num_starting_lock_buttons=num_lock_buttons,
         )
     )

--- a/apworld/brotato/test/test_brotato_world.py
+++ b/apworld/brotato/test/test_brotato_world.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 from . import BrotatoTestBase
-from ._data_sets import BrotatoTestDataSet
+from .data_sets.loot_crates import BrotatoLootCrateTestDataSet
 
 
 class TestBrotatoWorld(BrotatoTestBase):
@@ -41,7 +41,7 @@ class TestBrotatoWorld(BrotatoTestBase):
                 assert list(self.world.waves_with_checks) == expected_waves_with_checks
 
     def test_common_loot_crate_groups_correct(self):
-        test_data: BrotatoTestDataSet
+        test_data: BrotatoLootCrateTestDataSet
         for test_data in self._test_data_set_subtests():
             common_crate_groups = self.world.common_loot_crate_groups
             assert len(common_crate_groups) == test_data.expected_results.num_common_crate_regions
@@ -55,7 +55,7 @@ class TestBrotatoWorld(BrotatoTestBase):
                 assert group.wins_to_unlock == test_data.expected_results.wins_required_per_common_region[index]
 
     def test_legendary_loot_crate_groups_correct(self):
-        test_data: BrotatoTestDataSet
+        test_data: BrotatoLootCrateTestDataSet
         for test_data in self._test_data_set_subtests():
             legendary_crate_groups = self.world.legendary_loot_crate_groups
             assert len(legendary_crate_groups) == test_data.expected_results.num_legendary_crate_regions

--- a/apworld/brotato/test/test_items.py
+++ b/apworld/brotato/test/test_items.py
@@ -4,6 +4,7 @@ from ..constants import MAX_SHOP_SLOTS
 from ..items import ItemName
 from ..options import ItemWeights, StartingShopLockButtonsMode
 from . import BrotatoTestBase
+from .data_sets.shop_slots import SHOP_SLOT_TEST_DATA_SETS
 
 
 class TestBrotatoItems(BrotatoTestBase):
@@ -89,74 +90,26 @@ class TestBrotatoItems(BrotatoTestBase):
         self.assertEqual(item_counts[self.world.create_item(ItemName.LEGENDARY_ITEM)], 20)
 
     def test_create_items_shop_slot_items(self):
-        for num_starting_shop_slots in range(MAX_SHOP_SLOTS):
-            with self.subTest(num_starting_shop_slots=num_starting_shop_slots):
-                expected_num_slot_items = MAX_SHOP_SLOTS - num_starting_shop_slots
-
-                self._run({"num_starting_shop_slots": num_starting_shop_slots})
+        for test_case in SHOP_SLOT_TEST_DATA_SETS:
+            with self.subTest(num_starting_shop_slots=test_case.num_starting_shop_slots):
+                self._run({"num_starting_shop_slots": test_case.num_starting_shop_slots})
                 item_counts = Counter(self.multiworld.itempool)
-                self.assertEqual(item_counts[self.world.create_item(ItemName.SHOP_SLOT)], expected_num_slot_items)
+                self.assertEqual(
+                    item_counts[self.world.create_item(ItemName.SHOP_SLOT)], test_case.expected_num_shop_slot_items
+                )
 
     def test_create_items_num_starting_lock_buttons(self):
-        for num_starting_lock_buttons in range(MAX_SHOP_SLOTS):
-            with self.subTest(num_starting_lock_buttons=num_starting_lock_buttons):
-                expected_num_lock_button_items = MAX_SHOP_SLOTS - num_starting_lock_buttons
-
+        for test_case in SHOP_SLOT_TEST_DATA_SETS:
+            with self.subTest(test_case=test_case):
                 self._run(
                     {
-                        "shop_lock_buttons_mode": StartingShopLockButtonsMode.option_custom,
-                        "num_starting_lock_buttons": num_starting_lock_buttons,
+                        "num_starting_shop_slots": test_case.num_starting_shop_slots,
+                        "shop_lock_buttons_mode": test_case.lock_button_mode.value,
+                        "num_starting_lock_buttons": test_case.num_starting_lock_buttons,
                     }
                 )
                 item_counts = Counter(self.multiworld.itempool)
                 self.assertEqual(
-                    item_counts[self.world.create_item(ItemName.SHOP_LOCK_BUTTON)], expected_num_lock_button_items
-                )
-
-    def test_create_items_shop_lock_buttons_mode_match_num_shop_slots_value(self):
-        for num_starting_shop_slots in range(MAX_SHOP_SLOTS):
-            with self.subTest(num_starting_shop_slots=num_starting_shop_slots):
-                expected_num_lock_button_items = MAX_SHOP_SLOTS - num_starting_shop_slots
-
-                self._run(
-                    {
-                        "shop_lock_buttons_mode": StartingShopLockButtonsMode.option_match_shop_slots,
-                        "num_starting_shop_slots": num_starting_shop_slots,
-                    }
-                )
-                item_counts = Counter(self.multiworld.itempool)
-                self.assertEqual(
-                    item_counts[self.world.create_item(ItemName.SHOP_LOCK_BUTTON)], expected_num_lock_button_items
-                )
-
-    def test_create_items_shop_lock_buttons_mode_no_starting_buttons(self):
-        for num_starting_shop_slots in range(MAX_SHOP_SLOTS):
-            with self.subTest(num_starting_shop_slots=num_starting_shop_slots):
-                expected_num_lock_button_items = MAX_SHOP_SLOTS
-
-                self._run(
-                    {
-                        "shop_lock_buttons_mode": StartingShopLockButtonsMode.option_none,
-                        "num_starting_shop_slots": num_starting_shop_slots,
-                    }
-                )
-                item_counts = Counter(self.multiworld.itempool)
-                self.assertEqual(
-                    item_counts[self.world.create_item(ItemName.SHOP_LOCK_BUTTON)], expected_num_lock_button_items
-                )
-
-    def test_create_items_shop_lock_buttons_mode_all_starting_buttons(self):
-        for num_starting_shop_slots in range(MAX_SHOP_SLOTS):
-            with self.subTest(num_starting_shop_slots=num_starting_shop_slots):
-                expected_num_lock_button_items = 0
-
-                self._run(
-                    {
-                        "shop_lock_buttons_mode": StartingShopLockButtonsMode.option_all,
-                        "num_starting_shop_slots": num_starting_shop_slots,
-                    }
-                )
-                item_counts = Counter(self.multiworld.itempool)
-                self.assertEqual(
-                    item_counts[self.world.create_item(ItemName.SHOP_LOCK_BUTTON)], expected_num_lock_button_items
+                    item_counts[self.world.create_item(ItemName.SHOP_LOCK_BUTTON)],
+                    test_case.expected_num_lock_button_items,
                 )

--- a/apworld/brotato/test/test_slot_data.py
+++ b/apworld/brotato/test/test_slot_data.py
@@ -1,5 +1,6 @@
 from ..options import StartingShopLockButtonsMode
 from . import BrotatoTestBase
+from .data_sets.shop_slots import SHOP_SLOT_TEST_DATA_SETS
 
 
 class TestBrotatoSlotData(BrotatoTestBase):
@@ -35,9 +36,20 @@ class TestBrotatoSlotData(BrotatoTestBase):
         self.assertEqual(slot_data["num_starting_shop_slots"], 1)
 
     def test_slot_data_starting_shop_lock_buttons(self):
-        slot_data = self.world.fill_slot_data()
-        # There should be 2 lock button items, and therefore two starting lock buttons
-        self.assertEqual(slot_data["num_starting_shop_lock_buttons"], 2)
+        for test_case in SHOP_SLOT_TEST_DATA_SETS:
+            with self.subTest(msg=str(test_case)):
+                self._run(
+                    {
+                        "num_starting_shop_slots": test_case.num_starting_shop_slots,
+                        "shop_lock_buttons_mode": test_case.lock_button_mode.value,
+                        "num_starting_lock_buttons": test_case.num_starting_lock_buttons,
+                    }
+                )
+
+                slot_data = self.world.fill_slot_data()
+                self.assertEqual(
+                    slot_data["num_starting_shop_lock_buttons"], test_case.expected_num_starting_lock_buttons
+                )
 
     def test_slot_data_num_common_crate_locations(self):
         slot_data = self.world.fill_slot_data()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_items_container.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/shop/shop_items_container.gd
@@ -18,7 +18,9 @@ func _ready():
 		_update_lock_buttons()
 
 func _update_lock_buttons():
+	ModLoaderLog.info("Updating lock buttons", LOG_NAME)
 	for shop_item_idx in range(_shop_items.size()):
 		var shop_item = _shop_items[shop_item_idx]
 		shop_item.ap_lock_button_enabled = shop_item_idx < _lock_buttons_progress.num_unlocked_shop_lock_buttons
+		ModLoaderLog.info("slot %d: lock_button_enabled=%s" % [shop_item_idx, shop_item.ap_lock_button_enabled], LOG_NAME)
 		shop_item.manage_lock_button_visibility()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/shop_lock_buttons.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/shop_lock_buttons.gd
@@ -2,6 +2,8 @@
 extends "res://mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd"
 class_name ApShopLockButtonsProgress
 
+const LOG_NAME = "RampagingHippy-Archipelago/progress/shop_lock_buttons"
+
 var num_starting_shop_lock_buttons: int
 var num_unlocked_shop_lock_buttons: int
 
@@ -14,8 +16,14 @@ func _init(ap_client, game_state).(ap_client, game_state):
 func on_item_received(item_name: String, _item):
 	if item_name == constants.SHOP_LOCK_BUTTON_ITEM_NAME:
 		num_unlocked_shop_lock_buttons += 1
+		ModLoaderLog.info("Shop lock button received, count=%d" % num_unlocked_shop_lock_buttons, LOG_NAME)
 		emit_signal("shop_lock_button_item_received")
 
 func on_connected_to_multiworld():
 	num_starting_shop_lock_buttons = _ap_client.slot_data["num_starting_shop_lock_buttons"]
 	num_unlocked_shop_lock_buttons = num_starting_shop_lock_buttons
+	ModLoaderLog.info(
+		"num_starting_shop_lock_buttons=%d, num_unlocked_shop_lock_buttons=%d" % 
+		[num_starting_shop_lock_buttons, num_unlocked_shop_lock_buttons], 
+		LOG_NAME
+	)


### PR DESCRIPTION
Trying to track down an issue with shop lock items not being given properly in some cases. Hopefully these logs will help.

Also, added tests data sets to check every combination of `num_starting_shop_slots`, `shop_lock_buttons_mode`, and `num_starting_lock_buttons`, then added tests to check that the generated items and slot data matched the expected results for each combination.

This also involved a minor refactor of the loot crate-related test data to make it match the new format for data sets, so we can scale better.