### PR TITLE
Fix logic for determining the bottom neighbor of the AP connect button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed not being able to reach the AP connect button on the main menu when scrolling up
+  through the menu options with a controller or the keyboard.
+
 ### Changed
 
 - Added more logging to the lock shop slot button-related logic to try and track down a

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/pages/main_menu.gd
@@ -22,7 +22,7 @@ func init():
 		# here for it take.
 		quit_button.focus_neighbour_bottom = _archipelago_button.get_path()
 		var bottom_neighbor
-		if ProgressData.saved_run_state.size() > 0:
+		if ProgressData.saved_run_state.get("has_run_state", false):
 			bottom_neighbor = continue_button
 		else:
 			bottom_neighbor = start_button


### PR DESCRIPTION
The data structure for ProgressData.saved_run_state changed, and our previous check was not valid, so we aloways set the bottom_neighbor of the AP connect button to the continue button, even if it wasn't visible.

The new check properly determines if there is a saved run or not.