### PR TITLE
Fix too many pickups spawning

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
@@ -4,10 +4,20 @@ class_name GodotApClientDebugSettings
 const LOG_NAME = "RampagingHippy-Archipelago/ap/debug"
 
 # When enabled, drop loot crate every n kills. Referenced in main and item_service.
-var enable_auto_spawn_loot_crate: bool = false
+var enable_auto_spawn_loot_crate: bool = true
 var auto_spawn_loot_crate: bool = false
 var auto_spawn_loot_crate_counter: int = 0
-var auto_spawn_loot_crate_on_count: int = 10
+var auto_spawn_loot_crate_on_count: int = 5
 
 func _init():
 	ModLoaderLog.debug("debug_spawn_loot_crate=%s" % enable_auto_spawn_loot_crate, LOG_NAME)
+
+func notify_enemy_killed():
+	if enable_auto_spawn_loot_crate:
+		auto_spawn_loot_crate_counter += 1
+		if auto_spawn_loot_crate_counter > auto_spawn_loot_crate_on_count:
+			auto_spawn_loot_crate = true
+
+func notify_debug_crate_spawned():
+	auto_spawn_loot_crate = false
+	auto_spawn_loot_crate_counter = 0

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/debug.gd
@@ -4,7 +4,7 @@ class_name GodotApClientDebugSettings
 const LOG_NAME = "RampagingHippy-Archipelago/ap/debug"
 
 # When enabled, drop loot crate every n kills. Referenced in main and item_service.
-var enable_auto_spawn_loot_crate: bool = true
+var enable_auto_spawn_loot_crate: bool = false
 var auto_spawn_loot_crate: bool = false
 var auto_spawn_loot_crate_counter: int = 0
 var auto_spawn_loot_crate_on_count: int = 5

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/entities/entity.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/entities/entity.gd
@@ -1,0 +1,24 @@
+extends "res://entities/entity.gd"
+
+const LOG_NAME = "RampagingHippy-Archipelago/entities/entity"
+
+onready var _ap_client
+
+func _ready():
+	var mod_node = get_node("/root/ModLoader/RampagingHippy-Archipelago")
+	_ap_client = mod_node.brotato_ap_client
+
+func die(args := DieArgs.new()) -> void:
+	var old_unit_always_drop_consumable = self.stats.always_drop_consumables
+	_ap_client.debug.notify_enemy_killed()
+	if _ap_client.debug.auto_spawn_loot_crate:
+		ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
+		# Tell the unit to drop a consumable
+		self.stats.always_drop_consumables = true
+		# Tell our item_service extension to force the consumable to be a
+		# loot crate
+		_ap_client.debug.auto_spawn_loot_crate = true
+		_ap_client.debug.auto_spawn_loot_crate_counter = 0
+
+	.die(args)
+	self.stats.always_drop_consumables = old_unit_always_drop_consumable

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -26,13 +26,12 @@ func _ready() -> void:
 	if _ap_client.connected_to_multiworld():
 		if RunData.current_wave == DebugService.starting_wave:
 			# Run started, notify the AP game state tracker.
-			
 			# Wait a very short time before sending the notify_run_started event to
 			# ensure the rest of the game is initialized. As of the 1.1.8.0 patch,
 			# collecting enough XP to level up too early causes the game to crash
 			# because the "Level Up" floating text is not fully initialized yet. This
 			# isn't elegant, but it doesn't negatively impact UX and it works.
-			yield(get_tree().create_timer(0.01), "timeout")
+			yield (get_tree().create_timer(0.01), "timeout")
 			var active_characters = []
 			for player in RunData.players_data:
 				active_characters.append(player.current_character.my_id)
@@ -97,8 +96,8 @@ func _on_ap_item_received(item_tier: int):
 
 func _on_ap_upgrade_received(upgrade_tier: int):
 	var upgrade_level: int
-	# Brotato gives items of set tiers at multiples of 5. Use this to give the correct
-	# tier item without modifying the original code too much.
+	# Brotato gives items of set tiers at multiples of 5. Use this to give the
+	# correct tier item without modifying the original code too much.
 	match upgrade_tier:
 		Tier.COMMON:
 			# We override get_upgrade_data to set the tier to COMMON if the level is -1.
@@ -118,8 +117,8 @@ func _on_ap_upgrade_received(upgrade_tier: int):
 		upgrade_to_process.player_index = player_index
 		_upgrades_to_process[player_index].push_back(upgrade_to_process)
 		# Mark the upgrade as processed here instead of where it's actually
-		# processed in _on_EndWaveTimer_timeout. It's a lot simpler to do here and
-		# the end result is the same either way.
+		# processed in _on_EndWaveTimer_timeout. It's a lot simpler to do here
+		# and the end result is the same either way.
 		_ap_client.upgrades_progress.process_ap_upgrade(upgrade_tier, player_index)
 
 # Base overrides
@@ -135,13 +134,20 @@ func spawn_consumables(unit: Unit) -> void:
 			ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
 			# Tell the unit to drop a consumable
 			unit.stats.always_drop_consumables = true
-			# Tell our item_service extension to force the consumable to be a loot crate
+			# Tell our item_service extension to force the consumable to be a
+			# loot crate
 			_ap_client.debug.auto_spawn_loot_crate = true
 		.spawn_consumables(unit)
 		unit.stats.always_drop_consumables = old_unit_always_drop_consumable
 		_ap_client.debug.auto_spawn_loot_crate = false
 	else:
 		.spawn_consumables(unit)
+	
+	# The base spawn_consumables yields until the spawned consumable is ready.
+	# For whatever reason, we can't chain off the yield here, so as a workaround
+	# we delay for a frame to wait for it to finish. There's no reason this
+	# should ever take more than a frame.
+	yield (get_tree(), "idle_frame")
 
 	var consumable_count_after = _consumables.size()
 	var spawned_consumable = consumable_count_after > consumable_count_start
@@ -149,8 +155,8 @@ func spawn_consumables(unit: Unit) -> void:
 		var spawned_consumable_id = _consumables.back().consumable_data.my_id
 		if spawned_consumable_id == "ap_pickup":
 			_ap_client.common_loot_crate_progress.notify_crate_spawned()
-			# Increment this to help the game calculate drops appropriately. They do the
-			# same for normal loot crate drops.
+			# Increment this to help the game calculate drops appropriately.
+			# They do the same for normal loot crate drops.
 			_items_spawned_this_wave += 1
 		elif spawned_consumable_id == "ap_legendary_pickup":
 			_ap_client.legendary_loot_crate_progress.notify_crate_spawned()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -64,7 +64,8 @@ func _ready() -> void:
 		
 		var _status = _ap_client.items_progress.connect("item_received", self, "_on_ap_item_received")
 		_status = _ap_client.upgrades_progress.connect("upgrade_received", self, "_on_ap_upgrade_received")
-		
+		_status = _ap_client.common_loot_crate_progress.connect("ap_crate_spawned", self, "_on_ap_crate_spawned")
+		_status = _ap_client.legendary_loot_crate_progress.connect("ap_crate_spawned", self, "_on_ap_crate_spawned")
 		ModLoaderMod.append_node_in_scene(
 			self,
 			"ApLootCrateProgress",
@@ -120,6 +121,12 @@ func _on_ap_upgrade_received(upgrade_tier: int):
 		# processed in _on_EndWaveTimer_timeout. It's a lot simpler to do here
 		# and the end result is the same either way.
 		_ap_client.upgrades_progress.process_ap_upgrade(upgrade_tier, player_index)
+
+func _on_ap_crate_spawned():
+	# Increment the item spawned counter when we drop a loot crate. The base
+	# game only checks the normal loot crates, so adding this helps the game
+	# calculate drops appropriately.
+	_items_spawned_this_wave += 1
 
 # Base overrides
 func on_consumable_picked_up(consumable: Node, player_index: int) -> void:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
@@ -33,19 +33,22 @@ func get_consumable_for_tier(tier: int = Tier.COMMON) -> ConsumableData:
 	# actual instance is created later, so we can just drop the original return
 	# value if necessary without hurting anything.
 	var consumable
-	if _ap_client.debug.enable_auto_spawn_loot_crate and _ap_client.debug.auto_spawn_loot_crate:
+	if _ap_client.debug.auto_spawn_loot_crate:
 		# Debug tool is tellng is to forcibly drop an item box, ignore base game path
+		_ap_client.debug.notify_debug_crate_spawned()
 		if tier == Tier.LEGENDARY:
 			consumable = _base_game_legendary_item_box
 		else:
 			consumable = _base_game_item_box
 	else:
-		consumable = .get_consumable_for_tier(tier)
+		consumable =.get_consumable_for_tier(tier)
 
 	# Replace with corrsponding AP item if possible
 	if _ap_client.common_loot_crate_progress.can_spawn_consumable and consumable.my_id == ITEM_BOX_ID:
+		_ap_client.common_loot_crate_progress.notify_crate_spawned()
 		return _ap_normal_consuamble.duplicate()
 	elif _ap_client.legendary_loot_crate_progress.can_spawn_consumable and consumable.my_id == LEGENDARY_ITEM_BOX_ID:
+		_ap_client.legendary_loot_crate_progress.notify_crate_spawned()
 		return _ap_legendary_consumable.duplicate()
 	else:
 		return consumable
@@ -56,8 +59,8 @@ func process_item_box(consumable_data: ConsumableData, wave: int, player_index: 
 			var item_tier = consumable_data.tier
 			var item_wave = _ap_client.items_progress.process_ap_item(item_tier, player_index)
 			ModLoaderLog.debug(
-				"Processing AP item of tier %d at wave %d for player %d" 
-				% [item_tier, item_wave, player_index], 
+				"Processing AP item of tier %d at wave %d for player %d"
+				% [item_tier, item_wave, player_index],
 				LOG_NAME
 			)
 			# Adapted from the base process_item_box
@@ -66,11 +69,11 @@ func process_item_box(consumable_data: ConsumableData, wave: int, player_index: 
 			args.fixed_tier = item_tier
 			return _get_rand_item_for_wave(item_wave, player_index, TierData.ITEMS, args)
 		_:
-			return .process_item_box(consumable_data, wave, player_index)
+			return.process_item_box(consumable_data, wave, player_index)
 
 func get_upgrade_data(level: int, player_index: int) -> UpgradeData:
 	if level >= 0:
-		return .get_upgrade_data(level, player_index)
+		return.get_upgrade_data(level, player_index)
 	else:
 		# We set the level to -1 for AP common upgrade drops. For other tiers we can use
 		# existing logic by setting the level equal to a certain multiple of 5. This way
@@ -90,4 +93,4 @@ func get_player_shop_items(wave: int, player_index: int, args: ItemServiceGetSho
 			args.count = ap_num_shop_slots
 		ModLoaderLog.debug("Calling get_player_shop_items base with args.count=%d" % args.count, LOG_NAME)
 	
-	return .get_player_shop_items(wave, player_index, args)
+	return.get_player_shop_items(wave, player_index, args)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/item_service.gd
@@ -69,11 +69,11 @@ func process_item_box(consumable_data: ConsumableData, wave: int, player_index: 
 			args.fixed_tier = item_tier
 			return _get_rand_item_for_wave(item_wave, player_index, TierData.ITEMS, args)
 		_:
-			return.process_item_box(consumable_data, wave, player_index)
+			return .process_item_box(consumable_data, wave, player_index)
 
 func get_upgrade_data(level: int, player_index: int) -> UpgradeData:
 	if level >= 0:
-		return.get_upgrade_data(level, player_index)
+		return .get_upgrade_data(level, player_index)
 	else:
 		# We set the level to -1 for AP common upgrade drops. For other tiers we can use
 		# existing logic by setting the level equal to a certain multiple of 5. This way
@@ -93,4 +93,4 @@ func get_player_shop_items(wave: int, player_index: int, args: ItemServiceGetSho
 			args.count = ap_num_shop_slots
 		ModLoaderLog.debug("Calling get_player_shop_items base with args.count=%d" % args.count, LOG_NAME)
 	
-	return.get_player_shop_items(wave, player_index, args)
+	return .get_player_shop_items(wave, player_index, args)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/mod_main.gd
@@ -21,6 +21,7 @@ func _init():
 	# Add extensions
 	var extension_files = [
 		"main.gd", # Update consumable drop logic to spawn AP items
+		"entities/entity.gd", # Track when units are killed to drop consumables in debug mode
 		"singletons/run_data.gd", # Override XP rewards
 		"singletons/item_service.gd", # Drop AP consumables
 		"ui/menus/pages/main_menu.gd", # Add AP connect
@@ -50,7 +51,6 @@ func _ready() -> void:
 	# TODO: Proper translations
 	# ModLoaderLog.info(str("Translation Demo: ", tr("MODNAME_READY_TEXT")), LOG_NAME)
 	# ModLoaderLog.success("Loaded", LOG_NAME)
-
 	# TODO: Config migrations, add version number and check for matching values.
 	var config = ModLoaderConfig.get_config(MOD_NAME, "ap_config")
 	if config == null:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -45,6 +45,9 @@ class LootCrateGroup:
 ## Emitted when a crate is picked up to indicate the updated progress to the next check.
 signal check_progress_changed(progress, total)
 
+## Emitted when the game decides to drop an AP item.
+signal ap_crate_spawned
+
 # The total number of loot crate checks available.
 var total_checks: int
 
@@ -139,7 +142,7 @@ func _update_check_progress(new_value: int):
 		false
 	)
 
-func _update_num_locations_checked(new_value: int, send_check: bool=true):
+func _update_num_locations_checked(new_value: int, send_check: bool = true):
 	if num_locations_checked == new_value:
 		return
 
@@ -247,7 +250,7 @@ func on_run_started(_character_ids: Array):
 	_num_crates_spawned = 0
 	_update_can_spawn_consumable()
 
-func _on_session_data_storage_updated(key: String, new_value, _original_value=null):
+func _on_session_data_storage_updated(key: String, new_value, _original_value = null):
 	if key == _check_progress_data_storage_key:
 		ModLoaderLog.info("Received check progress DS update: key=%s, new_value=%d" % [key, new_value], LOG_NAME)
 		_update_check_progress(new_value)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -102,6 +102,7 @@ func notify_crate_spawned():
 	_num_crates_spawned += 1
 	ModLoaderLog.info("AP item spawned, total is %d" % _num_crates_spawned, LOG_NAME)
 	_update_can_spawn_consumable()
+	emit_signal("ap_crate_spawned")
 
 func notify_crate_picked_up():
 	## Called by the game extensions when an AP loot crate is picked up in-game.

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -97,11 +97,13 @@ func _init(ap_client, game_state, crate_type_: String).(ap_client, game_state):
 func notify_crate_spawned():
 	## Called by the game extensions when an AP loot crate is spawned in-game.
 	_num_crates_spawned += 1
+	ModLoaderLog.info("AP item spawned, total is %d" % _num_crates_spawned, LOG_NAME)
 	_update_can_spawn_consumable()
 
 func notify_crate_picked_up():
 	## Called by the game extensions when an AP loot crate is picked up in-game.
 	_num_crates_spawned -= 1
+	ModLoaderLog.info("AP item picked up, total is %d" % _num_crates_spawned, LOG_NAME)
 	_update_check_progress(check_progress + 1)
 
 func total_locations_checked() -> int:


### PR DESCRIPTION
A recent update changed the base `spawn_consumables` function to have an `await` inside it to delay until the item was spawned before finishing. For whatever reason, I couldn't chain the await into the mod code, so I decided to just move all of the logic into `item_service` instead. This has the benefit of consolidating the logic into one place.

This also necessitated moving the debug crate spawning logic to a new location, which wound up being a split of the entity `die` method, and `item_service`.