### PR TITLE
Add item weights for items, upgrades, XP and gold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,12 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- World generation should now be generally more reliable, with less fill errors.
+
 ### Added
 
 - Added new option `num_characters` to determine how many characters to include
   in the generated world.
   - Character selection options behave the same, except we only choose
     `num_characters` characters instead of all included characters now.
+- Added new options to specify item, upgrade, gold and XP drop weights.
+  - Weights are used to randomly create a pool of the above items for all unfilled
+    locations.
+  - The default value of the weights are chosen to give the following distribution:
+    - 40% Items
+    - 40% Upgrades
+    - 10% Gold
+    - 10% XP
+  - Further, the weights per-rarity for items and upgrades are chosen to give a
+    distribution of items roughly matching the base game.
+
+### Changed
+- Legendary loot crate locations are no longer classified as `EXCLUDED`, and progression
+  and useful items may now be placed at them.
+  - This was the source of several fill bugs, and the easiest way to fix this was to
+    just make them normal locations.
+  - These were originally excluded because it was assumed they would be difficult to
+    get, and could lead to blocks in multiworlds. In practice, players can get strong
+    enough to easily kill elites/bosses with the amount of items in the pool.
+
+### Removed
+
+- The `item_weight_mode` option has been removed, as it's no longer relevant with the
+  new weight options.
+  - The weight presets can be replicated by either:
+    - Keeping the weights as their default values (`option_default`).
+    - Setting some/all weights to be random (`option_chaos`).
+    - Setting some/all weights manually ('`option_custom`).
+- The `Number<Common/Uncommon/Rare/Legendary>Upgrades` options have been removed, as
+  they are no longer relevant with the new weight options.
+
 
 ## [0.7.2] - 2025-02-11
 

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -139,14 +139,6 @@ class BrotatoWorld(World):
     Calculated from player options in generate_early().
     """
 
-    # _upgrade_and_item_counts: dict[ItemName, int]
-    """Amount of each upgrade tier and Brotato item to add to the item pool.
-
-    Calculated from player options in generate_early(). The counts may be less than the actual amount requested if there
-    is not enough locations for them all (which can happen if too many characters are excluded from having progression
-    items), in which case items from here will be randomly removed until they fit.
-    """
-
     nonessential_item_counts: dict[ItemName, int]
     """The names and counts of the items in the pool that aren't characters, shop slots, or shop locks.
 

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -20,6 +20,7 @@ from .constants import (
     RUN_COMPLETE_LOCATION_TEMPLATE,
     WAVE_COMPLETE_LOCATION_TEMPLATE,
     CharacterGroup,
+    ItemRarity,
 )
 from .item_weights import create_items_from_weights
 from .items import BrotatoItem, ItemName, filler_items, item_name_groups, item_name_to_id, item_table
@@ -126,18 +127,6 @@ class BrotatoWorld(World):
     Calculated from player options in generate_early.
     """
 
-    wave_per_game_item: Dict[int, List[int]]
-    """The wave to use to generate each Brotato item received, by rarity. Stored as slot data.
-
-    Brotato items are generated from a pool determined by the rarity (or tier) and the wave the item was found/bought.
-    We want to emulate this behavior with the items we create here. When we generate the items to match the common loot
-    crate drop locations, we also assign a wave to each item. When the client receives the next item for a certain
-    rarity, it will lookup the next entry in the list for the rarity and use that as the wave when generating the
-    values.
-
-    We attempt to equally distribute the items over the 20 waves in a normal run, with a bias towards lower numbers.
-    """
-
     common_loot_crate_groups: List[BrotatoLootCrateGroup]
     """Information about each common loot crate group, i.e. how many crates it has and how many wins it needs.
 
@@ -158,8 +147,8 @@ class BrotatoWorld(World):
     items), in which case items from here will be randomly removed until they fit.
     """
 
-    nonessential_item_names: list[ItemName]
-    """The names of the items in the pool that aren't characters, shop slots, or shop locks.
+    nonessential_item_counts: dict[ItemName, int]
+    """The names and counts of the items in the pool that aren't characters, shop slots, or shop locks.
 
     This includes the (Brotato) items, upgrades, gold and XP drops, which are populated from the respective weight
     options to fill all locations not taken by the aforementioned items.
@@ -247,19 +236,19 @@ class BrotatoWorld(World):
         )
 
         num_filler_items = max(num_locations - num_essential_items, 0)
-        self.nonessential_item_names = create_items_from_weights(
+        self.nonessential_item_counts = create_items_from_weights(
             num_filler_items,
             self.random,
-            self.options.common_item_weight.value,
-            self.options.uncommon_item_weight.value,
-            self.options.rare_item_weight.value,
-            self.options.legendary_item_weight.value,
-            self.options.common_upgrade_weight.value,
-            self.options.uncommon_item_weight.value,
-            self.options.rare_item_weight.value,
-            self.options.legendary_item_weight.value,
-            self.options.gold_weight.value,
-            self.options.xp_weight.value,
+            self.options.common_item_weight,
+            self.options.uncommon_item_weight,
+            self.options.rare_item_weight,
+            self.options.legendary_item_weight,
+            self.options.common_upgrade_weight,
+            self.options.uncommon_upgrade_weight,
+            self.options.rare_upgrade_weight,
+            self.options.legendary_upgrade_weight,
+            self.options.gold_weight,
+            self.options.xp_weight,
         )
 
     def set_rules(self) -> None:
@@ -297,7 +286,8 @@ class BrotatoWorld(World):
                 item_pool.append(character_item)
 
         # Create an item for each nonessential item. These are determined in generate_early().
-        item_pool += [self.create_item(item_name) for item_name in self.nonessential_item_names]
+        for item_name, item_count in self.nonessential_item_counts.items():
+            item_pool += [self.create_item(item_name) for _ in range(item_count)]
 
         item_pool += [self.create_item(ItemName.SHOP_SLOT) for _ in range(self.num_shop_slot_items)]
         item_pool += [self.create_item(ItemName.SHOP_LOCK_BUTTON) for _ in range(self.num_shop_lock_button_items)]
@@ -319,6 +309,7 @@ class BrotatoWorld(World):
         spawn_normal_loot_crates = (
             self.options.spawn_normal_loot_crates.value == self.options.spawn_normal_loot_crates.option_true
         )
+        wave_per_game_item = self._get_wave_per_game_item(self.nonessential_item_counts)
         return {
             "waves_with_checks": self.waves_with_checks,
             "num_wins_needed": self.options.num_victories.value,
@@ -334,7 +325,7 @@ class BrotatoWorld(World):
             "num_legendary_crate_locations": self.options.num_legendary_crate_drops.value,
             "num_legendary_crate_drops_per_check": self.options.num_legendary_crate_drops_per_check.value,
             "legendary_crate_drop_groups": [asdict(g) for g in self.legendary_loot_crate_groups],
-            "wave_per_game_item": self.wave_per_game_item,
+            "wave_per_game_item": wave_per_game_item,
             "enable_abyssal_terrors_dlc": self.options.enable_abyssal_terrors_dlc.value,
         }
 
@@ -374,7 +365,7 @@ class BrotatoWorld(World):
             loot_crate_groups = self.legendary_loot_crate_groups
             location_name_template = LEGENDARY_CRATE_DROP_LOCATION_TEMPLATE
             region_name_template = LEGENDARY_CRATE_DROP_GROUP_REGION_TEMPLATE
-            progress_type = LocationProgressType.EXCLUDED
+            progress_type = LocationProgressType.DEFAULT
 
         regions: List[Region] = []
         crate_count = 1
@@ -405,3 +396,36 @@ class BrotatoWorld(World):
         # In case the number of included characters is less than the requested amount
         num_characters_to_choose = min(len(valid_characters), self.options.num_starting_characters.value)
         return self.random.sample(valid_characters, num_characters_to_choose)
+
+    def _get_wave_per_game_item(self, item_counts: dict[ItemName, int]) -> dict[int, list[int]]:
+        """Determine the wave to use to generate each Brotato item received, by rarity.
+
+        Intended to be stored as slot data, which is why we use the (integer) enum values instead of the enums
+        themselves.
+
+        Brotato items are generated from a pool determined by the rarity (or tier) and the wave the item was
+        found/bought. We want to emulate this behavior with the items we create here. When we generate the items to
+        match the common loot crate drop locations, we also assign a wave to each item. When the client receives the
+        next item for a certain rarity, it will lookup the next entry in the list for the rarity and use that as the
+        wave when generating the values.
+
+        We attempt to equally distribute the items over the 20 waves in a normal run, with a bias towards lower numbers,
+        since it's already too easy to get overpowered in this.
+        """
+
+        item_names_to_rarity = {
+            ItemName.COMMON_ITEM: ItemRarity.COMMON,
+            ItemName.UNCOMMON_ITEM: ItemRarity.UNCOMMON,
+            ItemName.RARE_ITEM: ItemRarity.RARE,
+            ItemName.LEGENDARY_ITEM: ItemRarity.LEGENDARY,
+        }
+
+        def generate_waves_per_item(num_items: int) -> list[int]:
+            # Evenly distribute the items over 20 waves, then sort so items received are generated with steadily
+            # increasing waves (aka they got steadily stronger).
+            return sorted((i % NUM_WAVES) + 1 for i in range(num_items))
+
+        wave_per_item: dict[int, list[int]] = {}
+        for item_name, item_rarity in item_names_to_rarity.items():
+            wave_per_item[item_rarity.value] = generate_waves_per_item(item_counts[item_name])
+        return wave_per_item

--- a/apworld/brotato/__init__.py
+++ b/apworld/brotato/__init__.py
@@ -59,26 +59,23 @@ class BrotatoWeb(WebWorld):
             ],
         ),
         OptionGroup(
-            "Item Rewards",
+            "Shop Slots",
+            [options.StartingShopSlots, options.StartingShopLockButtonsMode, options.NumberStartingShopLockButtons],
+        ),
+        OptionGroup(
+            "Item Weights",
             [
                 options.CommonItemWeight,
                 options.UncommonItemWeight,
                 options.RareItemWeight,
                 options.LegendaryItemWeight,
-            ],
-        ),
-        OptionGroup(
-            "Upgrades",
-            [
                 options.CommonUpgradeWeight,
                 options.UncommonUpgradeWeight,
                 options.RareUpgradeWeight,
                 options.LegendaryUpgradeWeight,
+                options.GoldWeight,
+                options.XpWeight,
             ],
-        ),
-        OptionGroup(
-            "Shop Slots",
-            [options.StartingShopSlots, options.StartingShopLockButtonsMode, options.NumberStartingShopLockButtons],
         ),
         OptionGroup(
             "Abyssal Terrors DLC",

--- a/apworld/brotato/item_weights.py
+++ b/apworld/brotato/item_weights.py
@@ -1,0 +1,50 @@
+import itertools
+import math
+from random import Random
+
+from .items import ItemName, item_name_groups
+
+
+def create_items_from_weights(
+    num_items: int,
+    random: Random,
+    common_item_weight: int,
+    uncommon_item_weight: int,
+    rare_item_weight: int,
+    legendary_item_weight: int,
+    common_upgrade_weight: int,
+    uncommon_upgrade_weight: int,
+    rare_upgrade_weight: int,
+    legendary_upgrade_weight: int,
+    gold_weight: int,
+    xp_weight: int,
+) -> list[ItemName]:
+    gold_items = [ItemName(g) for g in sorted(item_name_groups["Gold"])]
+    xp_items = [ItemName(x) for x in sorted(item_name_groups["XP"])]
+    gold_item_weights = _create_weights_for_item_group(gold_weight, gold_items)
+    xp_item_weights = _create_weights_for_item_group(xp_weight, xp_items)
+    item_name_to_weight: dict[ItemName, int] = {
+        ItemName.COMMON_ITEM: common_item_weight,
+        ItemName.UNCOMMON_ITEM: uncommon_item_weight,
+        ItemName.RARE_ITEM: rare_item_weight,
+        ItemName.LEGENDARY_ITEM: legendary_item_weight,
+        ItemName.COMMON_UPGRADE: common_upgrade_weight,
+        ItemName.UNCOMMON_UPGRADE: uncommon_upgrade_weight,
+        ItemName.RARE_UPGRADE: rare_upgrade_weight,
+        ItemName.LEGENDARY_UPGRADE: legendary_upgrade_weight,
+        **gold_item_weights,
+        **xp_item_weights,
+    }
+    return random.sample(list(item_name_to_weight.keys()), num_items, counts=item_name_to_weight.values())
+
+
+def _create_weights_for_item_group(weight: int, group: list[ItemName]) -> dict[ItemName, int]:
+    base_weight, base_extra = divmod(weight, len(group))
+
+    base_extra = math.ceil(base_extra)
+    item_weights: dict[ItemName, int] = {item: base_weight for item in group}
+    while base_extra > 0:
+        for item in itertools.cycle(item_weights):
+            item_weights[item] += 1
+            base_extra -= 1
+    return item_weights

--- a/apworld/brotato/item_weights.py
+++ b/apworld/brotato/item_weights.py
@@ -35,7 +35,8 @@ def create_items_from_weights(
         **gold_item_weights,
         **xp_item_weights,
     }
-    return random.sample(list(item_name_to_weight.keys()), num_items, counts=item_name_to_weight.values())
+
+    return random.choices(list(item_name_to_weight.keys()), weights=list(item_name_to_weight.values()), k=num_items)
 
 
 def _create_weights_for_item_group(weight: int, group: list[ItemName]) -> dict[ItemName, int]:
@@ -43,8 +44,6 @@ def _create_weights_for_item_group(weight: int, group: list[ItemName]) -> dict[I
 
     base_extra = math.ceil(base_extra)
     item_weights: dict[ItemName, int] = {item: base_weight for item in group}
-    while base_extra > 0:
-        for item in itertools.cycle(item_weights):
-            item_weights[item] += 1
-            base_extra -= 1
+    for _, item in zip(range(base_extra), itertools.cycle(item_weights)):
+        item_weights[item] += 1
     return item_weights

--- a/apworld/brotato/item_weights.py
+++ b/apworld/brotato/item_weights.py
@@ -1,42 +1,53 @@
 import itertools
 import math
+from collections import Counter
 from random import Random
 
+from Options import OptionError
+
+from . import options
 from .items import ItemName, item_name_groups
 
 
 def create_items_from_weights(
     num_items: int,
     random: Random,
-    common_item_weight: int,
-    uncommon_item_weight: int,
-    rare_item_weight: int,
-    legendary_item_weight: int,
-    common_upgrade_weight: int,
-    uncommon_upgrade_weight: int,
-    rare_upgrade_weight: int,
-    legendary_upgrade_weight: int,
-    gold_weight: int,
-    xp_weight: int,
-) -> list[ItemName]:
+    common_item_weight: options.CommonItemWeight,
+    uncommon_item_weight: options.UncommonItemWeight,
+    rare_item_weight: options.RareItemWeight,
+    legendary_item_weight: options.LegendaryItemWeight,
+    common_upgrade_weight: options.CommonUpgradeWeight,
+    uncommon_upgrade_weight: options.UncommonUpgradeWeight,
+    rare_upgrade_weight: options.RareUpgradeWeight,
+    legendary_upgrade_weight: options.LegendaryUpgradeWeight,
+    gold_weight: options.GoldWeight,
+    xp_weight: options.XpWeight,
+) -> dict[ItemName, int]:
     gold_items = [ItemName(g) for g in sorted(item_name_groups["Gold"])]
     xp_items = [ItemName(x) for x in sorted(item_name_groups["XP"])]
-    gold_item_weights = _create_weights_for_item_group(gold_weight, gold_items)
-    xp_item_weights = _create_weights_for_item_group(xp_weight, xp_items)
+    gold_item_weights = _create_weights_for_item_group(gold_weight.value, gold_items)
+    xp_item_weights = _create_weights_for_item_group(xp_weight.value, xp_items)
     item_name_to_weight: dict[ItemName, int] = {
-        ItemName.COMMON_ITEM: common_item_weight,
-        ItemName.UNCOMMON_ITEM: uncommon_item_weight,
-        ItemName.RARE_ITEM: rare_item_weight,
-        ItemName.LEGENDARY_ITEM: legendary_item_weight,
-        ItemName.COMMON_UPGRADE: common_upgrade_weight,
-        ItemName.UNCOMMON_UPGRADE: uncommon_upgrade_weight,
-        ItemName.RARE_UPGRADE: rare_upgrade_weight,
-        ItemName.LEGENDARY_UPGRADE: legendary_upgrade_weight,
+        ItemName.COMMON_ITEM: common_item_weight.value,
+        ItemName.UNCOMMON_ITEM: uncommon_item_weight.value,
+        ItemName.RARE_ITEM: rare_item_weight.value,
+        ItemName.LEGENDARY_ITEM: legendary_item_weight.value,
+        ItemName.COMMON_UPGRADE: common_upgrade_weight.value,
+        ItemName.UNCOMMON_UPGRADE: uncommon_upgrade_weight.value,
+        ItemName.RARE_UPGRADE: rare_upgrade_weight.value,
+        ItemName.LEGENDARY_UPGRADE: legendary_upgrade_weight.value,
         **gold_item_weights,
         **xp_item_weights,
     }
 
-    return random.choices(list(item_name_to_weight.keys()), weights=list(item_name_to_weight.values()), k=num_items)
+    try:
+        chosen_items = random.choices(
+            list(item_name_to_weight.keys()), weights=list(item_name_to_weight.values()), k=num_items
+        )
+    except ValueError as ve:
+        # The Python docs state that random.choices raises a ValueError if all weights are zero.
+        raise OptionError("At least one item weight must be >0") from ve
+    return Counter(chosen_items)
 
 
 def _create_weights_for_item_group(weight: int, group: list[ItemName]) -> dict[ItemName, int]:

--- a/apworld/brotato/items.py
+++ b/apworld/brotato/items.py
@@ -165,18 +165,20 @@ item_name_groups: Dict[str, Set[str]] = {
         ItemName.LEGENDARY_UPGRADE.value,
     },
     "Shop": {ItemName.SHOP_SLOT.value, ItemName.SHOP_LOCK_BUTTON.value},
-    "Gold and XP": {
+    "Gold": {
+        ItemName.GOLD_10.value,
+        ItemName.GOLD_25.value,
+        ItemName.GOLD_50.value,
+        ItemName.GOLD_100.value,
+        ItemName.GOLD_200.value,
+    },
+    "XP": {
         ItemName.XP_5.value,
         ItemName.XP_10.value,
         ItemName.XP_25.value,
         ItemName.XP_50.value,
         ItemName.XP_100.value,
         ItemName.XP_150.value,
-        ItemName.GOLD_10.value,
-        ItemName.GOLD_25.value,
-        ItemName.GOLD_50.value,
-        ItemName.GOLD_100.value,
-        ItemName.GOLD_200.value,
     },
     "Characters": set(c.value for c in _char_items),
 }

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -258,27 +258,6 @@ class NumberLegendaryCrateDropGroups(Range):
     display_name: str = "Legendary Loot Crate Groups"
 
 
-class ItemWeights(Choice):
-    """Distribution of item tiers when adding (Brotato) items to the (Archipelago) item pool.
-
-    For every common crate drop location, a Brotato weapon/item will be added to the pool. This controls how the item
-    tiers are chosen.
-
-    Note that legendary crate drop locations will ALWAYS add a legendary item to the pool, which is in addition to any
-    legendary items added by common crate locations.
-
-    * Default: Use the game's normal distribution. Equivalent to setting the custom weights to 100/60/25/8.
-    * Chaos: Each tier has a has a random weight.
-    * Custom: Use the custom weight options below.
-    """
-
-    option_default = 0
-    option_chaos = 1
-    option_custom = 2
-
-    display_name = "Item Weights"
-
-
 class CommonItemWeight(Range):
     """The weight of Common/Tier 1/White items in the pool."""
 
@@ -323,7 +302,7 @@ class LegendaryItemWeight(Range):
     display_name = "Legendary Items"
 
 
-class NumberCommonUpgrades(Range):
+class CommonUpgradeWeight(Range):
     """The number of Common/Tier 1/White upgrades to include in the item pool."""
 
     range_start = 0
@@ -333,7 +312,7 @@ class NumberCommonUpgrades(Range):
     display_name: str = "Common Upgrades"
 
 
-class NumberUncommonUpgrades(Range):
+class UncommonUpgradeWeight(Range):
     """The number of Uncommon/Tier 2/Blue upgrades to include in the item pool."""
 
     range_start = 0
@@ -343,7 +322,7 @@ class NumberUncommonUpgrades(Range):
     display_name: str = "Uncommon Upgrades"
 
 
-class NumberRareUpgrades(Range):
+class RareUpgradeWeight(Range):
     """The number of Rare/Tier 3/Purple upgrades to include in the item pool."""
 
     range_start = 0
@@ -353,7 +332,7 @@ class NumberRareUpgrades(Range):
     display_name: str = "Rare Upgrades"
 
 
-class NumberLegendaryUpgrades(Range):
+class LegendaryUpgradeWeight(Range):
     """The number of Legendary/Tier 4/Red upgrades to include in the item pool."""
 
     range_start = 0
@@ -361,6 +340,45 @@ class NumberLegendaryUpgrades(Range):
 
     default = 5
     display_name = "Legendary Upgrades"
+
+
+class GoldWeight(Range):
+    """Weight of Gold items in the item pool.
+
+    The actual value of each gold item will we randomly picked from:
+
+    * 10
+    * 25
+    * 50
+    * 100
+    * 200
+    """
+
+    range_start = 0
+    range_end = 100
+
+    default = 5
+    display_name = "Gold Weight"
+
+
+class XpWeight(Range):
+    """Weight of XP items in the item pool.
+
+    The actual value of each XP item will we randomly picked from:
+
+    * 5
+    * 10
+    * 25
+    * 50
+    * 100
+    * 150
+    """
+
+    range_start = 0
+    range_end = 100
+
+    default = 5
+    display_name = "XP Weight"
 
 
 class StartingShopSlots(Range):
@@ -451,15 +469,16 @@ class BrotatoOptions(PerGameCommonOptions):
     num_legendary_crate_drops: NumberLegendaryCrateDropLocations
     num_legendary_crate_drops_per_check: NumberLegendaryCrateDropsPerCheck
     num_legendary_crate_drop_groups: NumberLegendaryCrateDropGroups
-    item_weight_mode: ItemWeights
     common_item_weight: CommonItemWeight
     uncommon_item_weight: UncommonItemWeight
     rare_item_weight: RareItemWeight
     legendary_item_weight: LegendaryItemWeight
-    num_common_upgrades: NumberCommonUpgrades
-    num_uncommon_upgrades: NumberUncommonUpgrades
-    num_rare_upgrades: NumberRareUpgrades
-    num_legendary_upgrades: NumberLegendaryUpgrades
+    common_upgrade_weight: CommonUpgradeWeight
+    uncommon_upgrade_weight: UncommonUpgradeWeight
+    rare_upgrade_weight: RareUpgradeWeight
+    legendary_upgrade_weight: LegendaryUpgradeWeight
+    gold_weight: GoldWeight
+    xp_weight: XpWeight
     num_starting_shop_slots: StartingShopSlots
     shop_lock_buttons_mode: StartingShopLockButtonsMode
     num_starting_lock_buttons: NumberStartingShopLockButtons

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -5,15 +5,11 @@ from Options import Choice, OptionSet, PerGameCommonOptions, Range, Toggle
 from .constants import (
     ABYSSAL_TERRORS_CHARACTERS,
     BASE_GAME_CHARACTERS,
-    MAX_COMMON_UPGRADES,
     MAX_LEGENDARY_CRATE_DROP_GROUPS,
     MAX_LEGENDARY_CRATE_DROPS,
-    MAX_LEGENDARY_UPGRADES,
     MAX_NORMAL_CRATE_DROP_GROUPS,
     MAX_NORMAL_CRATE_DROPS,
-    MAX_RARE_UPGRADES,
     MAX_SHOP_SLOTS,
-    MAX_UNCOMMON_UPGRADES,
     NUM_WAVES,
     TOTAL_NUM_CHARACTERS,
 )
@@ -335,7 +331,7 @@ class CommonUpgradeWeight(Range):
     """The number of Common/Tier 1/White upgrades to include in the item pool."""
 
     range_start = 0
-    range_end: int = MAX_COMMON_UPGRADES
+    range_end: int = 100
 
     default = 50
     display_name: str = "Common Upgrades"
@@ -345,7 +341,7 @@ class UncommonUpgradeWeight(Range):
     """The number of Uncommon/Tier 2/Blue upgrades to include in the item pool."""
 
     range_start = 0
-    range_end: int = MAX_UNCOMMON_UPGRADES
+    range_end: int = 100
 
     default = 30
     display_name: str = "Uncommon Upgrades"
@@ -355,7 +351,7 @@ class RareUpgradeWeight(Range):
     """The number of Rare/Tier 3/Purple upgrades to include in the item pool."""
 
     range_start = 0
-    range_end: int = MAX_RARE_UPGRADES
+    range_end: int = 100
 
     default = 12
     display_name: str = "Rare Upgrades"
@@ -365,7 +361,7 @@ class LegendaryUpgradeWeight(Range):
     """The number of Legendary/Tier 4/Red upgrades to include in the item pool."""
 
     range_start = 0
-    range_end = MAX_LEGENDARY_UPGRADES
+    range_end = 100
 
     default = 8
     display_name = "Legendary Upgrades"

--- a/apworld/brotato/options.py
+++ b/apworld/brotato/options.py
@@ -258,13 +258,42 @@ class NumberLegendaryCrateDropGroups(Range):
     display_name: str = "Legendary Loot Crate Groups"
 
 
+# Item weights
+#
+# The default values of each weight are meant to give a distribution of items matching:
+# - 20% Common Items
+# - 12% Uncommon Items
+# - 5% Rare Items
+# - 3% Legendary Items
+# - 20% Common Upgrades
+# - 12% Uncommon Upgrades
+# - 5% Rare Upgrades
+# - 3% Legendary Upgrades
+# - 10% Gold
+# - 10% XP
+#
+# Combining the items and upgrades of different rarities is:
+# - 40% Items
+# - 40% Upgrades
+# - 10% Gold
+# - 10% XP
+#
+# This distribution is a wild guess at a good default mix of items, upgrades, gold, and XP, and may be adjusted in the
+# future depending on player feedback.
+#
+# The ratios of common/uncommon/rare/legendary item and upgrades were chosen to roughly match the distribution of
+# common/uncommon/rare/legendary values in the game itself. This is determined by looking at the max chance of each
+# appearing in the shop as documented here: https://brotato.wiki.spellsandguns.com/Shop#Rarity_of_Shop_Items_and_Luck.
+# It's not a perfect approximation, but it "feels" correct.
+
+
 class CommonItemWeight(Range):
     """The weight of Common/Tier 1/White items in the pool."""
 
     range_start = 0
     range_end = 100
 
-    default = 100
+    default = 50
     display_name = "Common Items"
 
 
@@ -274,7 +303,7 @@ class UncommonItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    default = 60
+    default = 30
     display_name = "Uncommon Items"
 
 
@@ -284,7 +313,7 @@ class RareItemWeight(Range):
     range_start = 0
     range_end = 100
 
-    default = 25
+    default = 12
     display_name = "Rare Items"
 
 
@@ -308,7 +337,7 @@ class CommonUpgradeWeight(Range):
     range_start = 0
     range_end: int = MAX_COMMON_UPGRADES
 
-    default = 15
+    default = 50
     display_name: str = "Common Upgrades"
 
 
@@ -318,7 +347,7 @@ class UncommonUpgradeWeight(Range):
     range_start = 0
     range_end: int = MAX_UNCOMMON_UPGRADES
 
-    default = 10
+    default = 30
     display_name: str = "Uncommon Upgrades"
 
 
@@ -328,7 +357,7 @@ class RareUpgradeWeight(Range):
     range_start = 0
     range_end: int = MAX_RARE_UPGRADES
 
-    default = 5
+    default = 12
     display_name: str = "Rare Upgrades"
 
 
@@ -338,7 +367,7 @@ class LegendaryUpgradeWeight(Range):
     range_start = 0
     range_end = MAX_LEGENDARY_UPGRADES
 
-    default = 5
+    default = 8
     display_name = "Legendary Upgrades"
 
 
@@ -357,7 +386,7 @@ class GoldWeight(Range):
     range_start = 0
     range_end = 100
 
-    default = 5
+    default = 10
     display_name = "Gold Weight"
 
 
@@ -377,7 +406,7 @@ class XpWeight(Range):
     range_start = 0
     range_end = 100
 
-    default = 5
+    default = 10
     display_name = "XP Weight"
 
 

--- a/apworld/brotato/test/test_item_weights.py
+++ b/apworld/brotato/test/test_item_weights.py
@@ -1,0 +1,87 @@
+from random import Random
+from unittest import TestCase
+
+from Options import OptionError, Range
+
+from .. import options
+from ..item_weights import create_items_from_weights
+from ..items import ItemName, item_name_groups
+
+
+class TestBrotatoItemWeights(TestCase):
+    """Check that custom item weights are respected by setting weights for all but one item tier to 0 and confirming
+    only items of that tier are made.
+
+    It would be nice to test more option combinations, but there doesn't seem to be a good way to do so without
+    patching self.world.random, which makes the test tautological.
+    """
+
+    def test_all_weights_zero_except_one(self):
+        num_items = 100
+        option_to_expected_items: dict[type[Range], ItemName | list[ItemName]] = {
+            options.CommonItemWeight: ItemName.COMMON_ITEM,
+            options.UncommonItemWeight: ItemName.UNCOMMON_ITEM,
+            options.RareItemWeight: ItemName.RARE_ITEM,
+            options.LegendaryItemWeight: ItemName.LEGENDARY_ITEM,
+            options.CommonUpgradeWeight: ItemName.COMMON_UPGRADE,
+            options.UncommonUpgradeWeight: ItemName.UNCOMMON_UPGRADE,
+            options.RareUpgradeWeight: ItemName.RARE_UPGRADE,
+            options.LegendaryUpgradeWeight: ItemName.LEGENDARY_UPGRADE,
+            options.GoldWeight: [ItemName(name) for name in item_name_groups["Gold"]],
+            options.XpWeight: [ItemName(name) for name in item_name_groups["XP"]],
+        }
+        for active_weight, expected_items in option_to_expected_items.items():
+            with self.subTest(active_weight=active_weight):
+                weights = [opt(1) if opt is active_weight else opt(0) for opt in option_to_expected_items.keys()]
+                # We put the order of the dictionary keys in the same order as the expected arguments. Not pretty, but
+                # good enough without doing weird typing stuff.
+                item_names = create_items_from_weights(num_items, Random(0x12345), *weights)  # type: ignore
+                total_items = sum(item_names.values())
+                if not isinstance(expected_items, list):
+                    expected_items = [expected_items]
+                self.assertEqual(total_items, num_items)
+                for item_name in item_names:
+                    self.assertIn(item_name, expected_items)
+
+    def test_pair_of_weights_scale_properly(self):
+        item_names = create_items_from_weights(
+            100,
+            Random(0x34567),
+            options.CommonItemWeight(20),
+            options.UncommonItemWeight(0),
+            options.RareItemWeight(0),
+            options.LegendaryItemWeight(0),
+            options.CommonUpgradeWeight(10),  # Note that this is half of the weight for common items
+            options.UncommonUpgradeWeight(0),
+            options.RareUpgradeWeight(0),
+            options.LegendaryUpgradeWeight(0),
+            options.GoldWeight(0),
+            options.XpWeight(0),
+        )
+
+        total_items = sum(item_names.values())
+        self.assertEqual(total_items, 100)
+        self.assertSetEqual(set(item_names.keys()), {ItemName.COMMON_ITEM, ItemName.COMMON_UPGRADE})
+        item_count = item_names[ItemName.COMMON_ITEM]
+        upgrade_count = item_names[ItemName.COMMON_UPGRADE]
+
+        # We can't actually guarantee that item_count = 2 * upgrade_count, but with a sample size of 100 we should be
+        # able to guarantee that item_count > upgrade_count.
+        self.assertGreater(item_count, upgrade_count)
+
+    def test_all_weights_zero_raises_error(self):
+        with self.assertRaises(OptionError):
+            create_items_from_weights(
+                100,
+                Random(0x34567),
+                options.CommonItemWeight(0),
+                options.UncommonItemWeight(0),
+                options.RareItemWeight(0),
+                options.LegendaryItemWeight(0),
+                options.CommonUpgradeWeight(0),
+                options.UncommonUpgradeWeight(0),
+                options.RareUpgradeWeight(0),
+                options.LegendaryUpgradeWeight(0),
+                options.GoldWeight(0),
+                options.XpWeight(0),
+            )


### PR DESCRIPTION
This adds several new options to set the weight of the aforementioned items to control how often they appear in the item pool. 

The main motivation for this was to fix how these items were generated and added to the pool. Using weights, we can now simply calculate the number of locations in the world based on the options, determine from that how many items we need in addition to characters/shop related items, and generate the rest using the weights. This is a much more simple and reliable system than creating a requested amount of items, then reducing the counts until they match the number of locations.

Using weights also matches how existing apworlds implement similar features. It's also more "honest" to users, since in the past we were treating the number of upgrades as upper bounds instead of hard limits.

This also removes the upgrade count options, and the item weight option, since they aren't relevant with the weights.

One change also hidden in here is that legendary loot crates are now marked as normal locations instead of excluded, as a bandage to solve fill error issues. Not the best place for it, but we're making big changes in the test infra next so w/e.