### PR TITLE
Fix item wave values to properly distribute them over waves 1-20

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - World generation should now be generally more reliable, with less fill errors.
+- The method used to calculate the wave value used to generate each Brotato item given
+  has been updated to properly distribute the values over waves 1-20. Before, it would
+  bias towards lower values, and possibly not give any of higher waves if there were not
+  enough items.
 
 ### Added
 

--- a/apworld/brotato/test/test_waves.py
+++ b/apworld/brotato/test/test_waves.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from ..constants import ItemRarity
+from ..items import ItemName
 from ..options import WavesPerCheck
 from ..waves import get_wave_for_each_item, get_waves_with_checks
 
@@ -41,4 +43,92 @@ class TestWavesWithChecks(TestCase):
 
 class TestGetWaveForEachItem(TestCase):
     def test_get_wave_for_each_item(self):
-        pass
+        """Check some common values for the number of wave items to check they all yield the correct results.
+
+        For simplicity, we only run one invocation using a dict with the four item tiers, which essentially gives us
+        four tests in one, plus another testing the output structure is correct.
+
+        We don't test any values that don't fit evenly into the number of waves here to make it easy to check exact
+        results.
+        """
+        # Test multiple values using the same dict for simplicity
+        item_counts: dict[ItemName, int] = {
+            ItemName.COMMON_ITEM: 40,
+            ItemName.UNCOMMON_ITEM: 20,
+            ItemName.RARE_ITEM: 10,
+            ItemName.LEGENDARY_ITEM: 0,
+        }
+
+        expected_wave_per_item: dict[int, list[int]] = {
+            # 2 items at each wave
+            ItemRarity.COMMON.value: [
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5,
+                6,
+                6,
+                7,
+                7,
+                8,
+                8,
+                9,
+                9,
+                10,
+                10,
+                11,
+                11,
+                12,
+                12,
+                13,
+                13,
+                14,
+                14,
+                15,
+                15,
+                16,
+                16,
+                17,
+                17,
+                18,
+                18,
+                19,
+                19,
+                20,
+                20,
+            ],
+            # Bias towards earlier rounds if the count doesn't evenly divide by 20
+            ItemRarity.UNCOMMON.value: [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+            ],
+            ItemRarity.RARE.value: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+            ItemRarity.LEGENDARY.value: [],
+        }
+
+        wave_per_item = get_wave_for_each_item(item_counts)
+        self.assertDictEqual(wave_per_item, expected_wave_per_item)

--- a/apworld/brotato/waves.py
+++ b/apworld/brotato/waves.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from .constants import NUM_WAVES, ItemRarity
 from .items import ItemName
 from .options import WavesPerCheck
@@ -25,8 +27,8 @@ def get_wave_for_each_item(item_counts: dict[ItemName, int]) -> dict[int, list[i
     received. When the client receives the next item for a certain rarity, it will lookup the next entry in the list for
     the rarity and use that as the wave when generating the values.
 
-    We attempt to equally distribute the items over the 20 waves in a normal run, with a bias towards lower numbers,
-    since it's already too easy to get overpowered.
+    We attempt to equally distribute the items over the 20 waves in a normal run, with a bias towards higher numbers,
+    for fun.
     """
     item_names_to_rarity: dict[ItemName, ItemRarity] = {
         ItemName.COMMON_ITEM: ItemRarity.COMMON,
@@ -36,9 +38,20 @@ def get_wave_for_each_item(item_counts: dict[ItemName, int]) -> dict[int, list[i
     }
 
     def generate_waves_per_item(num_items: int) -> list[int]:
-        # Evenly distribute the items over 20 waves, then sort so items received are generated with steadily
-        # increasing waves (aka they got steadily stronger).
-        return sorted((i % 20) + 1 for i in range(num_items))
+        """Evenly distribute the items over 20 waves, then sort so items received are generated with steadily
+        increasing waves (aka they got steadily stronger).
+        """
+        values: list[int] = []
+        if num_items > 0:
+            # Simple linspace implementation, except we start distributing from the top so there's always at least one
+            # wave 20 item.
+            step: float = (NUM_WAVES) / num_items
+            wave_value: float = 20
+            while len(values) < num_items:
+                values.append(ceil(wave_value))
+                wave_value -= step
+                wave_value = max(wave_value, 1)
+        return sorted(values)
 
     # Use a default of 0 in case no items of a tier were created for whatever reason.
     return {


### PR DESCRIPTION
The attempt to bias the items towards lower waves just meant that the game wouldn't give any items higher wave numbers if the number of items was less than 20.

It's probably not great for balance, but there's bigger issues in that regard (this barely does anything in-game), and it leads to more natural results. For example, there will always be an item of wave 20 now, and the waves will actually be spaced along `[1, 20]` using a cheap `linspace` implementation.