### PR TITLE
Fix error message when structures despawn at the end of a wave.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has been updated to properly distribute the values over waves 1-20. Before, it would
   bias towards lower values, and possibly not give any of higher waves if there were not
   enough items.
+- Fix possible error when cleaning up structures at the end of a run.
 
 ### Added
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/entities/entity.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/entities/entity.gd
@@ -9,16 +9,21 @@ func _ready():
 	_ap_client = mod_node.brotato_ap_client
 
 func die(args := DieArgs.new()) -> void:
-	var old_unit_always_drop_consumable = self.stats.always_drop_consumables
-	_ap_client.debug.notify_enemy_killed()
-	if _ap_client.debug.auto_spawn_loot_crate:
-		ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
-		# Tell the unit to drop a consumable
-		self.stats.always_drop_consumables = true
-		# Tell our item_service extension to force the consumable to be a
-		# loot crate
-		_ap_client.debug.auto_spawn_loot_crate = true
-		_ap_client.debug.auto_spawn_loot_crate_counter = 0
+	var old_unit_always_drop_consumable = self.stats.get("always_drop_consumables")
+	if old_unit_always_drop_consumable != null:
+		# An enemy died, handle debug crates 
+		_ap_client.debug.notify_enemy_killed()
+		if _ap_client.debug.auto_spawn_loot_crate:
+			ModLoaderLog.debug("Debug spawning consumable", LOG_NAME)
+			# Tell the unit to drop a consumable
+			self.stats.always_drop_consumables = true
+			# Tell our item_service extension to force the consumable to be a
+			# loot crate
+			_ap_client.debug.auto_spawn_loot_crate = true
+			_ap_client.debug.auto_spawn_loot_crate_counter = 0
 
-	.die(args)
-	self.stats.always_drop_consumables = old_unit_always_drop_consumable
+		.die(args)
+		self.stats.always_drop_consumables = old_unit_always_drop_consumable
+	else:
+		# Some other entity (i.e. structure) died, don't do anything special.
+		.die(args)


### PR DESCRIPTION
Possible behavior change from 1.1.10.0 update, don't think it's hurting anything but no reason to call this logic regardless.

It was originally assumed there would be more fixes due to 1.1.10.0, hence the branch name, but subsequent patches on Brotato's end have seemingly fixed all of those.