### PR TITLE
Have the AP pickups heal the same as common/legendary crates 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Common AP pickups now heal for 3 HP, and legendary pickups now heal for 100 HP, just
+  like vanilla common and legendary loot crates.
+
 ## [0.8.0] - 2025-04-07
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_legendary_pickup/ap_legendary_pickup.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_legendary_pickup/ap_legendary_pickup.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" load_steps=4 format=2]
+[gd_resource type="Resource" load_steps=5 format=2]
 
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=1]
 [ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_outline.png" type="Texture" id=2]
+[ext_resource path="res://items/consumables/legendary_item_box/legendary_item_box_effect.tres" type="Resource" id=3]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=4]
 
 [resource]
@@ -12,7 +13,7 @@ icon = ExtResource( 2 )
 name = "Archipelago Legendary Pickup"
 tier = 0
 value = 0
-effects = [  ]
+effects = [ ExtResource( 3 ) ]
 tracking_text = ""
 is_lockable = true
 is_cursed = false

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_pickup/ap_pickup.tres
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/content/consumables/ap_pickup/ap_pickup.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" load_steps=4 format=2]
+[gd_resource type="Resource" load_steps=5 format=2]
 
 [ext_resource path="res://items/consumables/consumable_data.gd" type="Script" id=1]
 [ext_resource path="res://mods-unpacked/RampagingHippy-Archipelago/images/ap_logo_80_outline.png" type="Texture" id=2]
+[ext_resource path="res://items/consumables/fruit/fruit_effect.tres" type="Resource" id=3]
 [ext_resource path="res://items/consumables/item_box/item_box_pickup.wav" type="AudioStream" id=4]
 
 [resource]
@@ -12,7 +13,7 @@ icon = ExtResource( 2 )
 name = "Archipelago Pickup"
 tier = 0
 value = 0
-effects = [  ]
+effects = [ ExtResource( 3 ) ]
 tracking_text = ""
 is_lockable = true
 is_cursed = false


### PR DESCRIPTION
Common crates heal for 3 HP, legendary crates for 100. Add the same effects they use to the AP pickups so they act the same.