### PR TITLE
Brotato 1.1.11.0 fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inability to finish wave due to internal changes in Brotato 1.1.11.0 update.
+- Fix Archipelago button in main menu having transparent background.
+
 ## [0.8.1] - 2025-04-26
 
 ### Added

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -149,10 +149,10 @@ func on_consumable_picked_up(consumable: Node, player_index: int) -> void:
 			RunData.add_tracked_value(player_index, "item_bag", item_box_gold_effect)
 	.on_consumable_picked_up(consumable, player_index)
 
-func clean_up_room(is_last_wave: bool = false, is_run_lost: bool = false, is_run_won: bool = false) -> void:
-	_ap_client.game_state.notify_wave_finished(RunData.current_wave, is_run_lost, is_run_won)
+func clean_up_room() -> void:
+	_ap_client.game_state.notify_wave_finished(RunData.current_wave, _is_run_lost, _is_run_won)
 	# Exactly one of these will be set when the run is completed. Can't trust
 	# is_last_wave since it might be false on wave 20 if endless mode is selected.
-	if is_run_won or is_run_lost:
-		_ap_client.game_state.notify_run_finished(is_run_won)
-	.clean_up_room(is_last_wave, is_run_lost, is_run_won)
+	if _is_run_won or _is_run_lost:
+		_ap_client.game_state.notify_run_finished(_is_run_won)
+	.clean_up_room()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/archipelago_connect_button.tscn
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/pages/archipelago_connect_button.tscn
@@ -8,5 +8,6 @@ margin_right = 12.0
 margin_bottom = 20.0
 text = "Connect"
 icon = ExtResource( 2 )
+flat = false
 icon_align = 2
 script = ExtResource( 1 )

--- a/tools/extract_brotato.py
+++ b/tools/extract_brotato.py
@@ -54,7 +54,6 @@ def main():
         gdre_dir = Path(args.gdre_dir).resolve()
         os.environ["PATH"] = str(gdre_dir) + os.pathsep + os.environ["PATH"]
 
-    breakpoint()
     _ensure_gdre_tools()
 
     if output_dir.is_dir():


### PR DESCRIPTION
Fix issues related to internal changes in [Brotato 1.1.11.0](https://store.steampowered.com/news/app/1942280/view/499450652730065115?l=english):

* Fix the game freezing/crashing at the end of a wave due to the inputs to `clean_up_room` changing.
* Fix the Archipelago button on the main menu having a transparent background.

Also includes a small fix to get rid of a stray `breakpoint()` in `tools/extract_brotato`.