### PR TITLE
Fix game disconnect from large saves and other network-related errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The game will now attempt to connect with WSS first instead of WS, which should speed
   up connecting to archipelago.gg.
 - Update client version to 0.6.2 when connecting.
-- Set 'AP' tag when connecting.
 
 ## [0.9.0]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix game disconnecting from the MultiServer if there is a saved run bigger than the
+  mod's inbound buffer.
+
+### Changed
+
+- The game will now attempt to connect with WSS first instead of WS, which should speed
+  up connecting to archipelago.gg.
+- Update client version to 0.6.2 when connecting.
+- Set 'AP' tag when connecting.
+
 ## [0.9.0]
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
@@ -120,7 +120,7 @@ func send_connect(game: String, user: String, password: String = "", slot_data: 
 		"uuid": "Godot %s: %s" % [game, user], # TODO: What do we need here? We can't generate an actual UUID in 3.5
 		"version": {"major": 0, "minor": 6, "build": 2, "class": "Version"},
 		"items_handling": 0b111, # TODO: argument
-		"tags": ['AP'],
+		"tags": [],
 		"slot_data": slot_data
 	})
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
@@ -89,7 +89,7 @@ func connect_to_server(server: String) -> bool:
 		ws_success = yield (self, "_stop_waiting_to_connect")
 		_waiting_to_connect_to_server = null
 		if ws_success:
-			_url = wss_url
+			_url = ws_url
 	else:
 		_url = wss_url
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
@@ -89,7 +89,7 @@ func connect_to_server(server: String) -> bool:
 		ws_success = yield (self, "_stop_waiting_to_connect")
 		_waiting_to_connect_to_server = null
 		if ws_success:
-			_url = ws_url
+			_url = wss_url
 	else:
 		_url = wss_url
 
@@ -111,16 +111,16 @@ func disconnect_from_server():
 	# The "connection_closed" signal handler will take care of cleanup
 	_client.disconnect_from_host()
 
-func send_connect(game: String, user: String, password: String="", slot_data: bool=true):
+func send_connect(game: String, user: String, password: String = "", slot_data: bool = true):
 	_send_command({
 		"cmd": "Connect",
 		"game": game,
 		"name": user,
 		"password": password,
 		"uuid": "Godot %s: %s" % [game, user], # TODO: What do we need here? We can't generate an actual UUID in 3.5
-		"version": {"major": 0, "minor": 5, "build": 0, "class": "Version"},
+		"version": {"major": 0, "minor": 6, "build": 2, "class": "Version"},
 		"items_handling": 0b111, # TODO: argument
-		"tags": [],
+		"tags": ['AP'],
 		"slot_data": slot_data
 	})
 
@@ -207,7 +207,7 @@ func set_notify(keys: Array):
 	})
 
 # WebSocketClient callbacks
-func _on_connection_established(_proto=""):
+func _on_connection_established(_proto = ""):
 	# We succeeded, stop waiting and tell the caller.
 	ModLoaderLog.info("Successfully connected.", LOG_NAME)
 	emit_signal("_stop_waiting_to_connect", true)
@@ -217,7 +217,7 @@ func _on_connection_error():
 	ModLoaderLog.info("Connection error.", LOG_NAME)
 	emit_signal("_stop_waiting_to_connect", false)
 
-func _on_connection_closed(was_clean=false):
+func _on_connection_closed(was_clean = false):
 	ModLoaderLog.info("AP connection closed, clean: %s." % was_clean, LOG_NAME)
 	_set_connection_state(State.STATE_CLOSED)
 	_peer = null
@@ -233,16 +233,23 @@ func _on_data_received():
 	if received_data.result == null:
 		ModLoaderLog.error("Failed to parse JSON for %s" % received_data_str, LOG_NAME)
 		return
+#	ModLoaderLog.debug("Received payload with size %d" % received_data_str.length(), LOG_NAME)
 	for command in received_data.result:
 		_handle_command(command)
 
 # Internal plumbing
 func _send_command(args: Dictionary):
+#	if args['cmd'] == 'Set':
+#		ModLoaderLog.debug("Sending %s command for %s" % [args['cmd'], args['key']], LOG_NAME)
+#	else:
+#		ModLoaderLog.debug("Sending %s command" % args['cmd'], LOG_NAME)
 	var command_str = JSON.print([args])
 	if _peer != null:
 		var result = _peer.put_packet(command_str.to_ascii())
 		if result != 0:
-			ModLoaderLog.warning("Failed to send command, put_packet response is %d" % result, LOG_NAME)
+			var gpe = _peer.get_packet_error()
+			var client_state = _client.get_connection_status()
+			ModLoaderLog.warning("Failed to send command, put_packet response is %d, gpe is %d, client_status is %s" % [result, gpe, client_state], LOG_NAME)
 	else:
 		ModLoaderLog.warning("Peer is null!", LOG_NAME)
 
@@ -261,12 +268,22 @@ func _init_client():
 	_result = self._client.connect("connection_established", self, "_on_connection_established")
 	_result = self._client.connect("connection_error", self, "_on_connection_error")
 	
-	# Increase max buffer size to accommodate AP's larger payloads. The defaults are:
-	#   - Max in/out buffer = 64 KB
-	#   - Max in/out packets = 1024 
-	# We increase the in buffer to 256 KB because some messages we receive are too large
-	# for 64. The other defaults are fine though.
-	_result = _client.set_buffers(256, 1024, 64, 1024)
+	# Increase max buffer size to accommodate AP's larger payloads. The args 
+	# and their defaults are:
+	#	- input_buffer_size_kb = 64 KB
+	#	- input_max_packets = 1024
+	#	- output_buffer_size_kb = 64 KB
+	#	- output_max_packets = 1024 
+	# We increase the input buffer to 10 MB because some messages we receive
+	# are too large	for 64K. It's huge, but it being too small has caused some
+	# nasty bugs in the past. The other defaults have been fine though.
+	# NOTE: Godot will silently drop packets that do not fit in the buffer! This
+	# can cause the WebSocket connection to time out because the messaging is
+	# not complete. If the game mysteriously drops the connection a few seconds
+	# after connecting, the buffer likely needs to be larger.
+	_result = _client.set_buffers(1024 * 10, 1024, 1024 * 10, 1024)
+	if _result:
+		ModLoaderLog.warning("Failed to set buffer sizes with error %d" % _result, LOG_NAME)
 
 	self._peer = null
 
@@ -285,7 +302,7 @@ func _set_connection_state(state):
 	emit_signal("connection_state_changed", connection_state)
 
 func _handle_command(command: Dictionary):
-	ModLoaderLog.info("Received %s command" % command["cmd"] , LOG_NAME)	
+	ModLoaderLog.info("Received %s command" % command["cmd"], LOG_NAME)
 	match command["cmd"]:
 		"RoomInfo":
 			emit_signal("on_room_info", command)

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/progress_data.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/singletons/progress_data.gd
@@ -27,7 +27,7 @@ func save_run_state(
 			free_rerolls,
 			item_steals
 		)
-		var loader_v2 = ProgressDataLoaderV2.new(SAVE_DIR) # Dummy value
+		var loader_v2 = ProgressDataLoaderV2.new("user://ap_save.json") # Dummy value
 		_set_loader_properties(loader_v2, run_state)
 		var saved_run_serialized = loader_v2.serialize_run_state(run_state)
 		var ap_run_state = _ap_client.export_run_specific_progress_data()

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
@@ -49,8 +49,8 @@ func save_character_run(character: String, game_state: Dictionary, ap_state: Dic
 
 func on_data_storage_updated(key: String, new_value, _original_value = null):
 	if key == _saved_runs_data_storage_key:
-		ModLoaderLog.info("Received updated saved runs", LOG_NAME)
+		ModLoaderLog.info("Received updated saved runs from DS key: %s" % _saved_runs_data_storage_key, LOG_NAME)
 		_saved_runs = new_value
 	elif key == _last_played_char_data_storage_key:
-		ModLoaderLog.info("Received updated last played character: %s" % new_value, LOG_NAME)
+		ModLoaderLog.info("Received updated last played character, %s, from DS key: %s" % [new_value, _last_played_char_data_storage_key], LOG_NAME)
 		_last_played_char = new_value


### PR DESCRIPTION
The saved runs could be larger than the client's incoming buffer size of 256 KB, which would cause the data storage with the saves to be dropped by the client when connecting to the server, which ultimately would lead to the server disconnecting the client. This ups the in- and out-going buffer sizes to 10 MB. It's a bit overkill, but this isn't the first time buffer issues have caused bugs like this, and I want this to be the last.

We also did some smaller changes along this:
* Better logging in the WebSocket client to help detect issues faster.
* The client now tries to connect over `wss://` first, then tries `ws://` if that fails, rather than the opposite.
    * This makes connecting to archipelago.gg (which I am assuming is the most common connection) a bit faster.
* Update the `Connect` message version from 0.5.0 to 0.6.2.