### PR TITLE
Handle case where there are more items of a given tier than were selected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix game disconnecting from the MultiServer if there is a saved run bigger than the
   mod's inbound buffer.
+- Fix game error if a player has more Brotato Items than were selected in the options.
+  - This should only occur if someone uses the server console to give a player extra
+    items.
 
 ### Changed
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
@@ -62,7 +62,14 @@ func process_ap_item(item_tier: int, player_index: int) -> int:
 
 	# Lookup the wave to use to determine the item 
 	# The slot_data JSONifies the wave_per_game_item
-	var wave = wave_per_game_item[item_tier][wave_for_next_item]
+	var waves_for_item_tier = wave_per_game_item[item_tier]
+	var wave
+	if wave_for_next_item >= waves_for_item_tier.size():
+		# Maybe the player (probably me) cheat console'd in a bunch of items,
+		# just clamp to the last value
+		wave = waves_for_item_tier[-1]
+	else:
+		wave = waves_for_item_tier[wave_for_next_item]
 	return wave
 
 func on_item_received(item_name: String, _item):


### PR DESCRIPTION
This can occur when someone uses the server console to send a player items, which means our calculation of the wave for each item is wrong.

To fix, we just give every extra item a wave value of 20.