### PR TITLE
Compress saved runs and increase WS buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Further increased WebSocket buffer size to account for very large saved runs.
+
+### Changed
+- Saved runs are now compressed using [Zstandard](https://facebook.github.io/zstd/)
+  before being sent to the Archipelago data storage to reduce data size.
+  - Uncompressed runs are still supported, and are automatically compressed when 
+    re-saved.
+
 ## [0.9.1] - 2025-07-17
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/ap_websocket_connection.gd
@@ -274,14 +274,16 @@ func _init_client():
 	#	- input_max_packets = 1024
 	#	- output_buffer_size_kb = 64 KB
 	#	- output_max_packets = 1024 
-	# We increase the input buffer to 10 MB because some messages we receive
+	# We increase the input buffer to 20 MB because some messages we receive
 	# are too large	for 64K. It's huge, but it being too small has caused some
 	# nasty bugs in the past. The other defaults have been fine though.
+	# Hopefully once the compression update propagates we can turn this down to
+	# like ~5 MB.
 	# NOTE: Godot will silently drop packets that do not fit in the buffer! This
 	# can cause the WebSocket connection to time out because the messaging is
 	# not complete. If the game mysteriously drops the connection a few seconds
 	# after connecting, the buffer likely needs to be larger.
-	_result = _client.set_buffers(1024 * 10, 1024, 1024 * 10, 1024)
+	_result = _client.set_buffers(1024 * 20, 1024, 1024 * 20, 1024)
 	if _result:
 		ModLoaderLog.warning("Failed to set buffer sizes with error %d" % _result, LOG_NAME)
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
@@ -7,11 +7,30 @@
 ## Co-op runs are not saved for simplicity, since we expect that most players won't care
 ## about resuming them. There shouldn't be anything technical preventing this as a
 ## future update, however.
+##
+## Character runs are saved as a dictionary in data storage, where the key is the character ID
+## and the value is a dictionary of the following:
+##	- decompressed_size (int): The size of "data_b64" when decoded and decompressed, in bytes. 
+##	   Needed to call PoolByteArray.decompress.
+##	- compression (int): The compression format used to compress the data. Is one of
+##	   File.CompressionMode, currently should only ever be COMPRESSION_ZSTD (2).
+##	- data_b64 (String): The actual save data, compressed using the compression indicated by
+##	   "compression" then base64 encoded.
+##
+## When decompressed, "data_b64" becomes another dictionary containing:
+##	- game_state (Dictionary): The Brotato save game data. Matches what would be saved to file
+##	    normally.
+##	- ap_state (Dictionary): AP-specific save data, such as how many items/upgrades were received.
+##
+## Note that older versions of the mod did not use compression, and instead used the data in
+## "data_b64" as the value in data storage. We check for this case for backwards compatibility, but
+## eventually we should be able to remove support for this when no more slots use the old format.
 
 extends "res://mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd"
 class_name ApSavedRunsProgress
 
 const LOG_NAME = "RampagingHippy-Archipelago/progress/saved_runs"
+const _DEBUG_SAVE_NAME = "user://ap_debug_save_game"
 
 # Enable enemy XP (vanilla behavior) until we're connected to a multiworld.
 var _saved_runs_data_storage_key: String = ""
@@ -33,7 +52,35 @@ func on_connected_to_multiworld():
 	_ap_client.set_notify([_saved_runs_data_storage_key, _last_played_char_data_storage_key])
 
 func get_saved_run(character: String) -> Dictionary:
-	return _saved_runs.get(character, {})
+	if not _saved_runs.has(character):
+		ModLoaderLog.info("No saved run for %s" % character, LOG_NAME)
+		return {}
+	
+	var saved_run_raw = _saved_runs[character]
+	if saved_run_raw.has("data_b64"):
+		# Using new compressed format, convert and decompress
+		ModLoaderLog.info("Found compressed saved run for %s" % character, LOG_NAME)
+		var saved_run_bytes: PoolByteArray = Marshalls.base64_to_raw (saved_run_raw["data_b64"])
+		var compression_mode = saved_run_raw["compression"]
+		var decompressed_size = saved_run_raw["decompressed_size"]
+		var saved_run_decompressed = saved_run_bytes.decompress(decompressed_size, compression_mode)
+		var saved_run_str = saved_run_decompressed.get_string_from_utf8()
+		var parse_result = JSON.parse(saved_run_str)
+		if parse_result.error:
+			ModLoaderLog.error(
+				"Failed to parse saved character run: error=%s, error_line=%d, error_string=%s" % [
+					parse_result.error,
+					parse_result.error_line,
+					parse_result.error_string
+				],
+				LOG_NAME
+			)
+		return parse_result.result
+	else:
+		# Old uncompressed json format, just return
+		ModLoaderLog.info("Found uncompressed saved run for %s" % character, LOG_NAME)
+		return saved_run_raw
+
 
 func get_last_played_char():
 	return _last_played_char
@@ -43,8 +90,18 @@ func get_last_saved_run():
 
 func save_character_run(character: String, game_state: Dictionary, ap_state: Dictionary):
 	var combined_save_data = {"game_state": game_state, "ap_state": ap_state}
-	_saved_runs[character] = combined_save_data
-	_ap_client.set_value(_saved_runs_data_storage_key, "update", {character: combined_save_data})
+	var combined_save_data_bytes = JSON.print(combined_save_data).to_utf8()
+
+	var decompressed_data_size = combined_save_data_bytes.size()
+	var save_data_compressed = combined_save_data_bytes.compress(File.COMPRESSION_ZSTD)
+	var save_data_b64 = Marshalls.raw_to_base64(save_data_compressed)
+	var save_info = {
+		"compression": File.COMPRESSION_ZSTD,
+		"data_b64": save_data_b64, 
+		"decompressed_size": decompressed_data_size
+	}
+
+	_ap_client.set_value(_saved_runs_data_storage_key, "update", {character: save_info})
 	_ap_client.set_value(_last_played_char_data_storage_key, "replace", character)
 
 func on_data_storage_updated(key: String, new_value, _original_value = null):


### PR DESCRIPTION
Apparently the 10 MB buffer size was not large enough if enough large saved runs were stored in the AP data storage. Increase the buffer size to 20 MB and see if that's enough.

To avoid this problem in the future, saved runs are now compressed using Zstandard before being sent to data storage. This greatly decreases the save size, and long-term should hopefully mean saves all comfortably fit in a smaller buffer.

Old, uncompressed saves are still supported, and will be automatically compressed the next time they are saved.