### PR TITLE
Fix run won on death

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - Further increased WebSocket buffer size to account for very large saved runs.
+- Fixed dying on Wave 20 counting as a won run.
 
 ### Changed
+
 - Saved runs are now compressed using [Zstandard](https://facebook.github.io/zstd/)
   before being sent to the Archipelago data storage to reduce data size.
   - Uncompressed runs are still supported, and are automatically compressed when 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -150,9 +150,9 @@ func on_consumable_picked_up(consumable: Node, player_index: int) -> void:
 	.on_consumable_picked_up(consumable, player_index)
 
 func clean_up_room() -> void:
+	.clean_up_room()
 	_ap_client.game_state.notify_wave_finished(RunData.current_wave, _is_run_lost, _is_run_won)
 	# Exactly one of these will be set when the run is completed. Can't trust
 	# is_last_wave since it might be false on wave 20 if endless mode is selected.
 	if _is_run_won or _is_run_lost:
 		_ap_client.game_state.notify_run_finished(_is_run_won)
-	.clean_up_room()


### PR DESCRIPTION
The `_is_run_lost` flag is not set until the base game finishes its end of wave cleanup, and we were checking the flag before this happens. So, our wins tracker was erroneously giving a win if the player died on wave 20.

Reorder the sequence of base/mod clean up to fix this.