### PR TITLE
Fix errors when retrying and loading runs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed checks no longer being sent in a run if a failed wave is retried.
+- Fixed error when resuming a saved run from the main menu.
+
 ## [0.10.0] - 2025-08-06
 
 ### Fixed

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/game_state.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ap/game_state.gd
@@ -10,7 +10,7 @@ const LOG_NAME = "RampagingHippy-Archipelago/game_state"
 var GodotApClient = load("res://mods-unpacked/RampagingHippy-Archipelago/ap/godot_ap_client.gd")
 
 ## Signal that a new run has started with the given character.
-signal run_started(character_ids)
+signal run_started(character_ids, is_new_run)
 
 ## Signal that the current run has finished with the given character
 ##
@@ -34,16 +34,20 @@ func is_in_ap_run() -> bool:
 	## Returns true iff we're actively in a run and connected to an AP server.
 	return in_run and _ap_client.connect_state == GodotApClient.ConnectState.CONNECTED_TO_MULTIWORLD
 
-func notify_run_started(character_ids: Array):
+func notify_run_started(character_ids: Array, is_new_run: bool):
 	## Called by the game extensions when a new run is started.
 	##
-	## Emits the `run_started` signal to notify progress trackers.
+	## Emits the `run_started` signal to notify progress trackers. Passes along
+	## the `is_new_run` flag, which indicates whether the run was started
+	## completely new, or is starting from either a previously saved run, or
+	## retrying a failed wave. Progress trackers will behave accordingly and
+	## only initialize state that should be done at the start of the run if set.
 	in_run = true
 	active_characters = character_ids
 	var character_names = ", ".join(active_characters)
 	if is_in_ap_run():
 		ModLoaderLog.info("AP run started with characters; %s" % character_names, LOG_NAME)
-		emit_signal("run_started", active_characters)
+		emit_signal("run_started", active_characters, is_new_run)
 	else:
 		ModLoaderLog.info("Non-AP run started with characters; %s" % character_names, LOG_NAME)
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/main.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	_ap_client = mod_node.brotato_ap_client
 	
 	if _ap_client.connected_to_multiworld():
-		if RunData.current_wave == DebugService.starting_wave:
+		if RunData.current_wave == DebugService.starting_wave or not _ap_client.game_state.in_run:
 			# Run started, notify the AP game state tracker.
 			# Wait a very short time before sending the notify_run_started event to
 			# ensure the rest of the game is initialized. As of the 1.1.8.0 patch,
@@ -35,7 +35,8 @@ func _ready() -> void:
 			var active_characters = []
 			for player in RunData.players_data:
 				active_characters.append(player.current_character.my_id)
-			_ap_client.game_state.notify_run_started(active_characters)
+			var is_new_run = RunData.retries == 0
+			_ap_client.game_state.notify_run_started(active_characters, is_new_run)
 			
 		# Give player any unprocessed items and upgrades from the multiworld
 		for item_tier in _ap_client.items_progress.received_items_by_tier:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/_base.gd
@@ -66,7 +66,7 @@ func on_connected_to_multiworld():
 func on_disconnected_from_multiworld():
 	pass
 
-func on_run_started(_character_ids: Array):
+func on_run_started(_character_ids: Array, _is_new_run: bool):
 	pass
 
 func on_wave_finished(_wave_number: int, _character_ids: Array, _is_run_lost: bool, _is_run_won: bool):

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/gold.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/gold.gd
@@ -83,10 +83,13 @@ func on_connected_to_multiworld():
 		true
 	)
 
-func on_run_started(_character_ids: Array):
-	if gold_reward_mode == constants.GoldRewardMode.ALL_EVERY_TIME:
+func on_run_started(_character_ids: Array, is_new_run: bool):
+	if gold_reward_mode == constants.GoldRewardMode.ALL_EVERY_TIME and is_new_run:
 		# Reset the received gold so we give the player all gold items again.
+		# Do only when a run is started so we don't give them gold twice.
 		gold_given = 0
+	# Always give unreceived gold, even on retry, in case some came in while they were
+	# on the menu (maybe they went AFK?)
 	give_player_unreceived_gold()
 
 func export_run_specific_progress_data() -> Dictionary:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/items.gd
@@ -97,19 +97,21 @@ func on_connected_to_multiworld():
 		Tier.LEGENDARY: 0
 	}
 
-func on_run_started(character_ids: Array):
+func on_run_started(character_ids: Array, is_new_run: bool):
 	# Reset the number of items processed
 	# TODO: Per-player items
-	processed_items_by_player_by_tier = []
-	for _character_id in character_ids:
-		processed_items_by_player_by_tier.push_back(
-			{
-				Tier.COMMON: 0,
-				Tier.UNCOMMON: 0,
-				Tier.RARE: 0,
-				Tier.LEGENDARY: 0
-			}
-		)
+	if is_new_run:
+		# Assume the state is correct if we're retrying a wave
+		processed_items_by_player_by_tier = []
+		for _character_id in character_ids:
+			processed_items_by_player_by_tier.push_back(
+				{
+					Tier.COMMON: 0,
+					Tier.UNCOMMON: 0,
+					Tier.RARE: 0,
+					Tier.LEGENDARY: 0
+				}
+			)
 
 func export_run_specific_progress_data() -> Dictionary:
 	var data = {
@@ -123,7 +125,7 @@ func load_run_specific_progress_data(data: Dictionary):
 	processed_items_by_player_by_tier = []
 	var saved_processed_items = data[SAVE_DATA_KEY]["processed_items_by_player_by_tier"]
 	# If the data was loaded from JSON, the keys will be strings instead of ints
-	var is_string_key:bool  = not saved_processed_items[0].has(Tier.COMMON)
+	var is_string_key: bool = not saved_processed_items[0].has(Tier.COMMON)
 	var tier_keys = [Tier.COMMON, Tier.UNCOMMON, Tier.RARE, Tier.LEGENDARY]
 	for entry in saved_processed_items:
 		var player_processed_items = {}

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/loot_crates.gd
@@ -168,7 +168,8 @@ func _update_can_spawn_consumable():
 	var possible_checks = floor((check_progress + _num_crates_spawned) / crates_per_check)
 	can_spawn_consumable = num_locations_checked + possible_checks < num_unlocked_locations
 	ModLoaderLog.info(
-		"Updating can_spawn_consumable: check_progress=%d, crates_spawned=%d, crates_per_check=%d, num_locations_checked=%d, num_unlocked_locations=%d, can_spawn_consumable=%s" % [
+		"Updating %s can_spawn_consumable: check_progress=%d, crates_spawned=%d, crates_per_check=%d, num_locations_checked=%d, num_unlocked_locations=%d, can_spawn_consumable=%s" % [
+			crate_type,
 			check_progress,
 			_num_crates_spawned,
 			crates_per_check,
@@ -247,7 +248,8 @@ func on_connected_to_multiworld():
 		true
 	)
 
-func on_run_started(_character_ids: Array):
+func on_run_started(_character_ids: Array, _is_new_run: bool):
+	# Always reset the crates spawned to 0, just in case.
 	_num_crates_spawned = 0
 	_update_can_spawn_consumable()
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/saved_runs.gd
@@ -60,7 +60,7 @@ func get_saved_run(character: String) -> Dictionary:
 	if saved_run_raw.has("data_b64"):
 		# Using new compressed format, convert and decompress
 		ModLoaderLog.info("Found compressed saved run for %s" % character, LOG_NAME)
-		var saved_run_bytes: PoolByteArray = Marshalls.base64_to_raw (saved_run_raw["data_b64"])
+		var saved_run_bytes: PoolByteArray = Marshalls.base64_to_raw(saved_run_raw["data_b64"])
 		var compression_mode = saved_run_raw["compression"]
 		var decompressed_size = saved_run_raw["decompressed_size"]
 		var saved_run_decompressed = saved_run_bytes.decompress(decompressed_size, compression_mode)
@@ -86,7 +86,7 @@ func get_last_played_char():
 	return _last_played_char
 
 func get_last_saved_run():
-	return _saved_runs.get(_last_played_char, {})
+	return get_saved_run(_last_played_char)
 
 func save_character_run(character: String, game_state: Dictionary, ap_state: Dictionary):
 	var combined_save_data = {"game_state": game_state, "ap_state": ap_state}
@@ -97,7 +97,7 @@ func save_character_run(character: String, game_state: Dictionary, ap_state: Dic
 	var save_data_b64 = Marshalls.raw_to_base64(save_data_compressed)
 	var save_info = {
 		"compression": File.COMPRESSION_ZSTD,
-		"data_b64": save_data_b64, 
+		"data_b64": save_data_b64,
 		"decompressed_size": decompressed_data_size
 	}
 

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/upgrades.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/upgrades.gd
@@ -52,18 +52,20 @@ func on_connected_to_multiworld():
 		Tier.LEGENDARY: 0
 	}
 
-func on_run_started(character_ids: Array):
-	# Reset the number of upgrades processed
-	processed_upgrades_by_player_by_tier = []
-	for _char_id in character_ids:
-		processed_upgrades_by_player_by_tier.push_back(
-			{
-			Tier.COMMON: 0,
-			Tier.UNCOMMON: 0,
-			Tier.RARE: 0,
-			Tier.LEGENDARY: 0
-			}
-		)
+func on_run_started(character_ids: Array, is_new_run: bool):
+	# Reset the number of upgrades processed. Assume this is correct if loading/retrying
+	# a run.
+	if is_new_run:
+		processed_upgrades_by_player_by_tier = []
+		for _char_id in character_ids:
+			processed_upgrades_by_player_by_tier.push_back(
+				{
+				Tier.COMMON: 0,
+				Tier.UNCOMMON: 0,
+				Tier.RARE: 0,
+				Tier.LEGENDARY: 0
+				}
+			)
 
 func export_run_specific_progress_data() -> Dictionary:
 	return {

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/progress/xp.gd
@@ -82,10 +82,13 @@ func on_connected_to_multiworld():
 		true
 	)
 
-func on_run_started(_character_ids: Array):
-	if xp_reward_mode == constants.XpRewardMode.ALL_EVERY_TIME:
+func on_run_started(_character_ids: Array, is_new_run: bool):
+	if xp_reward_mode == constants.XpRewardMode.ALL_EVERY_TIME and is_new_run:
 		# Reset the received XP so we give the player all gold items again.
+		# Only do once when starting a run so we don't give a player gold twice.
 		xp_given = 0
+	# Always give unreceived XP, even on retry, in case some came in while they were
+	# on the menu (maybe they went AFK?)
 	give_player_unreceived_xp()
 
 func export_run_specific_progress_data() -> Dictionary:

--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/run/load_ap_run.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/ui/menus/run/load_ap_run.gd
@@ -89,12 +89,12 @@ func _on_ResumeButton_pressed():
 	var characters = []
 	for player_idx in RunData.get_player_count():
 		characters.push_back(RunData.get_player_character(player_idx).my_id)
-	_ap_client.game_state.notify_run_started(characters)
 	
 	ProgressData.saved_run_state = _saved_game_state
 	RunData.resume_from_state(_saved_game_state)
 	RunData.resumed_from_state_in_shop = true
 	_ap_client.load_run_specific_progress_data(_saved_ap_state)
+	_ap_client.game_state.notify_run_started(characters, false)
 	var scene = "res://ui/menus/shop/shop.tscn"
 	var _error = get_tree().change_scene(scene)
 


### PR DESCRIPTION
When a wave is failed, the mod calls `game_state.notify_run_finished` to indicate we're no longer in a run. However, if the player uses the option to restart the run from the last wave, we weren't calling `notify_run_started` properly. This is now fixed, and the check for calling `notify_run_started` in our `main` extension now automatically calls the method if we're connected to an AP server and it hasn't been called already by the resume run flow.

When retrying a wave, the game just rolls back `RunData` to its value at the start of the wave, so any setup we did for the run is already applied. To make sure that we don't redo these steps, we add a new argument to `notify_run_started` and the `game_state.run_started` signal, `is_new_run`, which is only set by the `main` extension if it notices that there's one more retries listed in `RunData`.

Also, fixed `ApSavedRunsProgress.get_last_saved_run` not decompressing the saved run data first, causing issues when trying to resume a run.