### PR TITLE
Disable the progress panel on the character select screen.

### DIFF
--- a/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/run/character_selection.gd
+++ b/client_mod/mods-unpacked/RampagingHippy-Archipelago/extensions/ui/menus/run/character_selection.gd
@@ -16,7 +16,9 @@ var _ui_crate_progress
 
 func _ready():
 	_ensure_ap_client()
-	_add_ap_progress_ui()
+	# Currently disabled because it causes the UI to be wider than the viewport,
+	# leading to weird issues mousing over characters.
+	# _add_ap_progress_ui()
 
 func _on_selections_completed():
 	_ensure_ap_client()


### PR DESCRIPTION
With the change to base Brotato to show a small animation of the selected character, the base UI is now wider. Our progress panel was pushing the width of the panel over the size of the screen, causing the entire UI to resize.

This was particularly annoying when mousing over characters, as the character select UI would now also move with the resize, meaning what the mouse was hovering over would change, causing flickering on the menu.

As of #122, the progress UI is now in the AP menu, so its information is still visible.